### PR TITLE
PHP 7.2

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Composer
         run: composer install --no-progress
 
+      - name: Check CS
+        run: vendor/bin/ecs
+
       - name: PHPUnit
         run: vendor/bin/phpunit --coverage-clover=coverage.xml
 

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -11,9 +11,9 @@ jobs:
     strategy:
       matrix:
         php:
-          - '5.6'
-          - '7.0'
-          - '7.1'
+          - '7.2'
+          - '7.3'
+          - '7.4'
 
     name: PHP ${{ matrix.php }} tests
 

--- a/.runConfigurations/EasyCodingStandard.run.xml
+++ b/.runConfigurations/EasyCodingStandard.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="EasyCodingStandard" type="PhpLocalRunConfigurationType" factoryName="PHP Console" path="$PROJECT_DIR$/vendor/bin/ecs" scriptParameters="--fix">
+    <CommandLine workingDirectory="$PROJECT_DIR$">
+      <envs>
+        <env name="XDEBUG_MODE" value="off" />
+      </envs>
+    </CommandLine>
+    <method v="2" />
+  </configuration>
+</component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - **BC break**: Wrap exceptions from SQS in package exception classes.
   If an implementation was catching `SqsException` it should now catch a
   `Phlib\JobQueue\Exception` class instead.
+### Removed
+- **BC break**: Removed support for PHP versions <= v7.1 as they are no longer
+  [actively supported](https://php.net/supported-versions.php) by the PHP project
 
 ## [1.1.1] - 2018-11-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Improve worker command handling exceptions from job queue library.
 - Worker command error log context keys changed to use `camelCase`.
+- **BC break**: Make return types consistent for `JobQueueInterface` methods.
+  - `put()` returns self. A job delayed in the DB used to return `true`,
+    otherwise Beanstalk used to return a Beanstalkd job ID.
+  - `retrieve()` returns `null` when not found. Beanstalk used to return `false`.
+  - `markAsComplete()`, `markAsIncomplete()` and `markAsError()` return self.
+    AWS returned void. Beanstalk sometimes returned the underlying connection.
 - **BC break**: Wrap exceptions from SQS in package exception classes.
   If an implementation was catching `SqsException` it should now catch a
   `Phlib\JobQueue\Exception` class instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Type declarations have been added to all method parameters and return types
+  where possible.
 ### Changed
 - Improve worker command handling exceptions from job queue library.
 - Worker command error log context keys changed to use `camelCase`.

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "symplify/easy-coding-standard": "^11",
-        "phpunit/phpunit": "~4.4"
+        "phpunit/phpunit": "^5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
 
         "phlib/beanstalk": "^1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "symplify/easy-coding-standard": "^11",
-        "phpunit/phpunit": "^5"
+        "phpunit/phpunit": "^6"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "aws/aws-sdk-php": "^3.61"
     },
     "require-dev": {
+        "symplify/easy-coding-standard": "^11",
         "phpunit/phpunit": "~4.4"
     },
     "autoload": {
@@ -38,5 +39,9 @@
            "Phlib\\JobQueue\\Tests\\": "tests/"
        }
     },
-    "bin": ["bin/jobqueue"]
+    "bin": ["bin/jobqueue"],
+    "scripts": {
+        "cs-check": "vendor/bin/ecs",
+        "cs-fix": "vendor/bin/ecs --fix"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "symplify/easy-coding-standard": "^11",
-        "phpunit/phpunit": "^6"
+        "phpunit/phpunit": "^7"
     },
     "autoload": {
         "psr-4": {

--- a/ecs.php
+++ b/ecs.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Symplify\EasyCodingStandard\Config\ECSConfig;
+use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
+
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->paths([
+        __DIR__ . '/bin',
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ]);
+
+    $ecsConfig->sets([
+        SetList::COMMON,
+        SetList::PSR_12,
+    ]);
+
+    $ecsConfig->skip([
+        // Remove sniff, from common/control-structures
+        \PhpCsFixer\Fixer\ClassNotation\OrderedClassElementsFixer::class,
+
+        // Remove sniff, from common/spaces
+        \PhpCsFixer\Fixer\Operator\NotOperatorWithSuccessorSpaceFixer::class,
+        \PhpCsFixer\Fixer\CastNotation\CastSpacesFixer::class,
+
+        // Save strict to later
+        \PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer::class,
+        \PhpCsFixer\Fixer\Strict\StrictParamFixer::class,
+        \PhpCsFixer\Fixer\Strict\StrictComparisonFixer::class,
+        \PhpCsFixer\Fixer\PhpUnit\PhpUnitStrictFixer::class,
+        \PhpCsFixer\Fixer\PhpUnit\PhpUnitSetUpTearDownVisibilityFixer::class,
+    ]);
+};

--- a/src/AwsSqs/JobFactory.php
+++ b/src/AwsSqs/JobFactory.php
@@ -10,7 +10,6 @@ use Phlib\JobQueue\JobInterface;
 class JobFactory
 {
     /**
-     * @param JobInterface $job
      * @return string
      */
     public static function serializeBody(JobInterface $job)
@@ -24,7 +23,7 @@ class JobFactory
         ]);
     }
 
-    public static function createFromRaw(array $data)
+    public static function createFromRaw(array $data): Job
     {
         if (!isset($data['ReceiptHandle'], $data['Body'])) {
             throw new InvalidArgumentException('Specified raw data is missing required elements.');
@@ -44,11 +43,9 @@ class JobFactory
     }
 
     /**
-     * @param array $data
-     * @return Job
      * @throws InvalidArgumentException
      */
-    public static function createFromSpecification(array $data)
+    public static function createFromSpecification(array $data): Job
     {
         if (!isset($data['body'], $data['queue'])) {
             throw new \InvalidArgumentException('Missing required job data.');

--- a/src/AwsSqs/JobFactory.php
+++ b/src/AwsSqs/JobFactory.php
@@ -16,11 +16,11 @@ class JobFactory
     public static function serializeBody(JobInterface $job)
     {
         return json_encode([
-            'queue'    => $job->getQueue(),
-            'body'     => $job->getBody(),
-            'delay'    => $job->getDelay(),
+            'queue' => $job->getQueue(),
+            'body' => $job->getBody(),
+            'delay' => $job->getDelay(),
             'priority' => $job->getPriority(),
-            'ttr'      => $job->getTtr()
+            'ttr' => $job->getTtr(),
         ]);
     }
 
@@ -31,7 +31,11 @@ class JobFactory
         }
         $specification = json_decode($data['Body'], true);
         if (!is_array($specification)) {
-            $job = static::createFromSpecification(['queue' => false, 'id' => $data['ReceiptHandle'], 'body' => 'false']);
+            $job = static::createFromSpecification([
+                'queue' => false,
+                'id' => $data['ReceiptHandle'],
+                'body' => 'false',
+            ]);
             throw new JobRuntimeException($job, 'Failed to extract job data.');
         }
 
@@ -57,9 +61,9 @@ class JobFactory
 
         // merge default values if any are missing
         $data += [
-            'delay'    => 0,
+            'delay' => 0,
             'priority' => 1024,
-            'ttr'      => 60
+            'ttr' => 60,
         ];
 
         return new Job($data['queue'], $data['body'], $id, $data['delay'], $data['priority'], $data['ttr']);

--- a/src/AwsSqs/JobQueue.php
+++ b/src/AwsSqs/JobQueue.php
@@ -46,15 +46,22 @@ class JobQueue implements JobQueueInterface
     }
 
     /**
-     * @inheritdoc
+     * @param mixed $data
+     * @param int|string|null $id
      */
-    public function createJob($queue, $data, $id = null, $delay = Job::DEFAULT_DELAY, $priority = Job::DEFAULT_PRIORITY, $ttr = Job::DEFAULT_TTR)
-    {
+    public function createJob(
+        string $queue,
+        $data,
+        $id = null,
+        $delay = Job::DEFAULT_DELAY,
+        $priority = Job::DEFAULT_PRIORITY,
+        $ttr = Job::DEFAULT_TTR
+    ): JobInterface {
         return new Job($queue, $data, $id, $delay, $priority, $ttr);
     }
 
     /**
-     * @inheritdoc
+     * @return $this|bool
      */
     public function put(JobInterface $job)
     {
@@ -74,10 +81,7 @@ class JobQueue implements JobQueueInterface
         }
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function retrieve($queue)
+    public function retrieve(string $queue): ?JobInterface
     {
         try {
             $result = $this->client->receiveMessage([
@@ -96,10 +100,7 @@ class JobQueue implements JobQueueInterface
         }
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function markAsComplete(JobInterface $job)
+    public function markAsComplete(JobInterface $job): void
     {
         try {
             $this->client->deleteMessage([
@@ -111,20 +112,14 @@ class JobQueue implements JobQueueInterface
         }
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function markAsIncomplete(JobInterface $job)
+    public function markAsIncomplete(JobInterface $job): void
     {
         $this->markAsComplete($job);
         $job->setDelay(0);
         $this->put($job);
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function markAsError(JobInterface $job)
+    public function markAsError(JobInterface $job): void
     {
         try {
             $queue = $job->getQueue();

--- a/src/Beanstalk/JobFactory.php
+++ b/src/Beanstalk/JobFactory.php
@@ -14,13 +14,7 @@ use Phlib\JobQueue\JobInterface;
  */
 class JobFactory
 {
-    /**
-     * @param array $data
-     * @return Job|false
-     * @throws InvalidArgumentException
-     * @throws JobRuntimeException
-     */
-    public static function createFromRaw(array $data)
+    public static function createFromRaw(array $data): Job
     {
         if (!isset($data['id']) || !isset($data['body'])) {
             throw new InvalidArgumentException('Specified raw data is missing required elements.');
@@ -40,12 +34,7 @@ class JobFactory
         return static::createFromSpecification($specification);
     }
 
-    /**
-     * @param array $data
-     * @return Job
-     * @throws InvalidArgumentException
-     */
-    public static function createFromSpecification(array $data)
+    public static function createFromSpecification(array $data): Job
     {
         if (!isset($data['body']) || !isset($data['queue'])) {
             throw new \InvalidArgumentException('Missing required job data.');
@@ -66,11 +55,7 @@ class JobFactory
         return new Job($data['queue'], $data['body'], $id, $data['delay'], $data['priority'], $data['ttr']);
     }
 
-    /**
-     * @param JobInterface $job
-     * @return string
-     */
-    public static function serializeBody(JobInterface $job)
+    public static function serializeBody(JobInterface $job): string
     {
         return serialize([
             'queue' => $job->getQueue(),

--- a/src/Beanstalk/JobFactory.php
+++ b/src/Beanstalk/JobFactory.php
@@ -2,11 +2,11 @@
 
 namespace Phlib\JobQueue\Beanstalk;
 
+use Phlib\Beanstalk\Connection;
 use Phlib\JobQueue\Exception\InvalidArgumentException;
 use Phlib\JobQueue\Exception\JobRuntimeException;
 use Phlib\JobQueue\Job;
 use Phlib\JobQueue\JobInterface;
-use Phlib\Beanstalk\Connection;
 
 /**
  * Class JobFactory
@@ -28,7 +28,11 @@ class JobFactory
 
         $specification = @unserialize($data['body']);
         if (!is_array($specification)) {
-            $job = static::createFromSpecification(['queue' => false, 'id' => $data['id'], 'body' => 'false']);
+            $job = static::createFromSpecification([
+                'queue' => false,
+                'id' => $data['id'],
+                'body' => 'false',
+            ]);
             throw new JobRuntimeException($job, 'Failed to extract job data.');
         }
 
@@ -54,9 +58,9 @@ class JobFactory
 
         // merge default values if any are missing
         $data = $data + [
-            'delay'    => Connection::DEFAULT_DELAY,
+            'delay' => Connection::DEFAULT_DELAY,
             'priority' => Connection::DEFAULT_PRIORITY,
-            'ttr'      => Connection::DEFAULT_TTR
+            'ttr' => Connection::DEFAULT_TTR,
         ];
 
         return new Job($data['queue'], $data['body'], $id, $data['delay'], $data['priority'], $data['ttr']);
@@ -69,11 +73,11 @@ class JobFactory
     public static function serializeBody(JobInterface $job)
     {
         return serialize([
-            'queue'    => $job->getQueue(),
-            'body'     => $job->getBody(),
-            'delay'    => $job->getDelay(),
+            'queue' => $job->getQueue(),
+            'body' => $job->getBody(),
+            'delay' => $job->getDelay(),
             'priority' => $job->getPriority(),
-            'ttr'      => $job->getTtr()
+            'ttr' => $job->getTtr(),
         ]);
     }
 }

--- a/src/Beanstalk/JobQueue.php
+++ b/src/Beanstalk/JobQueue.php
@@ -51,11 +51,10 @@ class JobQueue implements JobQueueInterface
     {
         if ($this->scheduler->shouldBeScheduled($job->getDelay())) {
             return $this->scheduler->store($job);
-        } else {
-            return $this->beanstalk
-                ->useTube($job->getQueue())
-                ->put(JobFactory::serializeBody($job), $job->getPriority(), $job->getDelay(), $job->getTtr());
         }
+        return $this->beanstalk
+            ->useTube($job->getQueue())
+            ->put(JobFactory::serializeBody($job), $job->getPriority(), $job->getDelay(), $job->getTtr());
     }
 
     /**
@@ -72,9 +71,13 @@ class JobQueue implements JobQueueInterface
      */
     public function setRetrieveTimeout($value)
     {
-        $options = ['options' => ['min_range' => 0]];
+        $options = [
+            'options' => [
+                'min_range' => 0,
+            ],
+        ];
         if ($value !== null && filter_var($value, FILTER_VALIDATE_INT, $options) === false) {
-            throw new InvalidArgumentException("Specified retrieve timeout value is not valid.");
+            throw new InvalidArgumentException('Specified retrieve timeout value is not valid.');
         }
         $this->retrieveTimeout = $value;
         return $this;
@@ -113,11 +116,10 @@ class JobQueue implements JobQueueInterface
                 $this->beanstalk->delete($job->getId());
             }
             return $this->scheduler->store($job);
-        } else {
-            return $this->beanstalk
-                ->useTube($job->getQueue())
-                ->release($job->getId(), $job->getPriority(), $job->getDelay());
         }
+        return $this->beanstalk
+            ->useTube($job->getQueue())
+            ->release($job->getId(), $job->getPriority(), $job->getDelay());
     }
 
     /**

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -3,8 +3,8 @@
 namespace Phlib\JobQueue\Command;
 
 use Phlib\ConsoleProcess\Command\DaemonCommand;
-use Phlib\JobQueue\Exception\InvalidArgumentException;
 use Phlib\JobQueue\Exception\Exception as LibraryException;
+use Phlib\JobQueue\Exception\InvalidArgumentException;
 use Phlib\JobQueue\JobInterface;
 use Phlib\JobQueue\JobQueueInterface;
 use Psr\Log\LoggerAwareInterface;
@@ -39,20 +39,20 @@ class WorkerCommand extends DaemonCommand implements LoggerAwareInterface
         }
 
         $jobQueue = $this->getJobQueue();
-        $logger   = $this->getLogger($output);
+        $logger = $this->getLogger($output);
 
         while ($this->continue && ($job = $this->retrieve($jobQueue, $logger)) instanceof JobInterface) {
             try {
                 $logger->info("Retrieved job {$job->getId()} for {$this->queue}");
                 $workStarted = microtime(true);
-                $code        = $this->work($job, $input, $output);
-                $timeTaken   = microtime(true) - $workStarted;
+                $code = $this->work($job, $input, $output);
+                $timeTaken = microtime(true) - $workStarted;
 
                 $debugCode = var_export($code, true);
                 $logger->debug("Work completed on job {$job->getId()} with return code '{$debugCode}' taking {$timeTaken}");
 
                 if ($code != 0) {
-                    throw new LogicException("Non zero exit code $code.");
+                    throw new LogicException("Non zero exit code {$code}.");
                 }
                 $jobQueue->markAsComplete($job);
                 $logger->info("Job {$job->getId()} completed");
@@ -126,17 +126,17 @@ class WorkerCommand extends DaemonCommand implements LoggerAwareInterface
     private function logException(LoggerInterface $logger, $message, \Exception $exception, $job = null)
     {
         $context = [
-            'qClass'    => get_class($this->getJobQueue()),
-            'xMessage'  => $exception->getMessage(),
-            'xFile'     => $exception->getFile(),
-            'xLine'     => $exception->getLine(),
-            'xTrace'    => $exception->getTraceAsString()
+            'qClass' => get_class($this->getJobQueue()),
+            'xMessage' => $exception->getMessage(),
+            'xFile' => $exception->getFile(),
+            'xLine' => $exception->getLine(),
+            'xTrace' => $exception->getTraceAsString(),
         ];
         if ($job instanceof JobInterface) {
-            $context['jId']       = $job->getId();
-            $context['jDelay']    = $job->getDelay();
+            $context['jId'] = $job->getId();
+            $context['jDelay'] = $job->getDelay();
             $context['jPriority'] = $job->getPriority();
-            $context['jTtr']      = $job->getTtr();
+            $context['jTtr'] = $job->getTtr();
         }
         $logger->error($message, $context);
     }

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -29,7 +29,7 @@ class WorkerCommand extends DaemonCommand implements LoggerAwareInterface
      */
     protected $exitOnException = false;
 
-    protected function execute(InputInterface $input, OutputInterface $output): void
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($this->queue === null) {
             throw new InvalidArgumentException("Missing require property 'queue' to be set on Worker Command.");
@@ -65,6 +65,8 @@ class WorkerCommand extends DaemonCommand implements LoggerAwareInterface
                 }
             }
         }
+
+        return 0;
     }
 
     /**

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -29,10 +29,7 @@ class WorkerCommand extends DaemonCommand implements LoggerAwareInterface
      */
     protected $exitOnException = false;
 
-    /**
-     * @inheritdoc
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         if ($this->queue === null) {
             throw new InvalidArgumentException("Missing require property 'queue' to be set on Worker Command.");
@@ -71,8 +68,6 @@ class WorkerCommand extends DaemonCommand implements LoggerAwareInterface
     }
 
     /**
-     * @param JobQueueInterface $jobQueue
-     * @param LoggerInterface $logger
      * @return JobInterface|null
      * @throws \Exception
      */
@@ -97,25 +92,17 @@ class WorkerCommand extends DaemonCommand implements LoggerAwareInterface
      * @throws LogicException When this abstract method is not implemented
      * @see setCode()
      */
-    protected function work(JobInterface $job, InputInterface $input, OutputInterface $output)
+    protected function work(JobInterface $job, InputInterface $input, OutputInterface $output): void
     {
         throw new LogicException('You must override the work() method in the concrete command class.');
     }
 
-    /**
-     * @return JobQueueInterface
-     * @throws LogicException
-     */
-    protected function getJobQueue()
+    protected function getJobQueue(): JobQueueInterface
     {
         throw new LogicException('You must override the getJobQueue() method in the concrete command class.');
     }
 
-    /**
-     * @param OutputInterface $output An OutputInterface instance
-     * @return \Psr\Log\LoggerInterface|NullLogger
-     */
-    protected function getLogger($output)
+    protected function getLogger(OutputInterface $output): LoggerInterface
     {
         if (!$this->logger) {
             $this->logger = new NullLogger();
@@ -123,7 +110,7 @@ class WorkerCommand extends DaemonCommand implements LoggerAwareInterface
         return $this->logger;
     }
 
-    private function logException(LoggerInterface $logger, $message, \Exception $exception, $job = null)
+    private function logException(LoggerInterface $logger, $message, \Exception $exception, $job = null): void
     {
         $context = [
             'qClass' => get_class($this->getJobQueue()),

--- a/src/Console/MonitorCommand.php
+++ b/src/Console/MonitorCommand.php
@@ -4,6 +4,7 @@ namespace Phlib\JobQueue\Console;
 
 use Phlib\ConsoleProcess\Command\DaemonCommand;
 use Phlib\JobQueue\Exception\InvalidArgumentException;
+use Phlib\JobQueue\JobInterface;
 use Phlib\JobQueue\JobQueueInterface;
 use Phlib\JobQueue\Scheduler\SchedulerInterface;
 use Symfony\Component\Console\Input\InputInterface;
@@ -28,7 +29,7 @@ class MonitorCommand extends DaemonCommand
      */
     protected $logFile;
 
-    protected function initialize(InputInterface $input, OutputInterface $output)
+    protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         $dependencies = $this->getHelper('configuration')
             ->fetch();
@@ -41,7 +42,7 @@ class MonitorCommand extends DaemonCommand
         $this->scheduler = $dependencies->getScheduler();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('monitor')
             ->setDescription('Monitor the schedule for pending jobs.')
@@ -49,10 +50,7 @@ class MonitorCommand extends DaemonCommand
         ;
     }
 
-    /**
-     * @inheritdoc
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $logFile = $input->getOption('log');
         if (!empty($logFile)) {
@@ -66,7 +64,7 @@ class MonitorCommand extends DaemonCommand
         }
     }
 
-    protected function createJob(array $schedulerJob)
+    protected function createJob(array $schedulerJob): JobInterface
     {
         return $this->jobQueue->createJob(
             $schedulerJob['queue'],
@@ -78,10 +76,7 @@ class MonitorCommand extends DaemonCommand
         );
     }
 
-    /**
-     * @return OutputInterface
-     */
-    protected function createChildOutput()
+    protected function createChildOutput(): OutputInterface
     {
         if (empty($this->logFile)) {
             return parent::createChildOutput();

--- a/src/Console/MonitorCommand.php
+++ b/src/Console/MonitorCommand.php
@@ -50,7 +50,7 @@ class MonitorCommand extends DaemonCommand
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): void
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $logFile = $input->getOption('log');
         if (!empty($logFile)) {
@@ -62,6 +62,8 @@ class MonitorCommand extends DaemonCommand
             $this->jobQueue->put($this->createJob($jobData));
             $this->scheduler->remove($jobData['id']);
         }
+
+        return 0;
     }
 
     protected function createJob(array $schedulerJob): JobInterface

--- a/src/Console/MonitorCommand.php
+++ b/src/Console/MonitorCommand.php
@@ -2,10 +2,10 @@
 
 namespace Phlib\JobQueue\Console;
 
-use Phlib\JobQueue\Scheduler\SchedulerInterface;
-use Phlib\JobQueue\JobQueueInterface;
-use Phlib\JobQueue\Exception\InvalidArgumentException;
 use Phlib\ConsoleProcess\Command\DaemonCommand;
+use Phlib\JobQueue\Exception\InvalidArgumentException;
+use Phlib\JobQueue\JobQueueInterface;
+use Phlib\JobQueue\Scheduler\SchedulerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -37,7 +37,7 @@ class MonitorCommand extends DaemonCommand
             throw new InvalidArgumentException('Expected dependencies could not be determined.');
         }
 
-        $this->jobQueue  = $dependencies->getJobQueue();
+        $this->jobQueue = $dependencies->getJobQueue();
         $this->scheduler = $dependencies->getScheduler();
     }
 

--- a/src/Console/MonitorDependencies.php
+++ b/src/Console/MonitorDependencies.php
@@ -21,28 +21,18 @@ class MonitorDependencies
      */
     protected $scheduler;
 
-    /**
-     * @param JobQueueInterface $jobQueue
-     * @param SchedulerInterface $scheduler
-     */
     public function __construct(JobQueueInterface $jobQueue, SchedulerInterface $scheduler)
     {
         $this->jobQueue = $jobQueue;
         $this->scheduler = $scheduler;
     }
 
-    /**
-     * @return JobQueueInterface
-     */
-    public function getJobQueue()
+    public function getJobQueue(): JobQueueInterface
     {
         return $this->jobQueue;
     }
 
-    /**
-     * @return SchedulerInterface
-     */
-    public function getScheduler()
+    public function getScheduler(): SchedulerInterface
     {
         return $this->scheduler;
     }

--- a/src/Exception/JobRuntimeException.php
+++ b/src/Exception/JobRuntimeException.php
@@ -9,35 +9,20 @@ class JobRuntimeException extends RuntimeException
     /**
      * @var JobInterface
      */
-    protected $job = null;
+    protected $job;
 
-    /**
-     * JobRuntimeException constructor.
-     * @param JobInterface $job
-     * @param string $message
-     * @param int $code
-     * @param Exception|null $previous
-     */
-    public function __construct($job, $message, $code = 0, Exception $previous = null)
+    public function __construct(?JobInterface $job, string $message, int $code = 0, \Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
-        if ($job instanceof JobInterface) {
-            $this->job = $job;
-        }
+        $this->job = $job;
     }
 
-    /**
-     * @return bool
-     */
-    public function hasJob()
+    public function hasJob(): bool
     {
         return $this->job !== null;
     }
 
-    /**
-     * @return JobInterface|null
-     */
-    public function getJob()
+    public function getJob(): ?JobInterface
     {
         return $this->job;
     }

--- a/src/Job.php
+++ b/src/Job.php
@@ -8,9 +8,11 @@ namespace Phlib\JobQueue;
  */
 class Job implements JobInterface
 {
-    public const DEFAULT_DELAY    = 0;
+    public const DEFAULT_DELAY = 0;
+
     public const DEFAULT_PRIORITY = 1024;
-    public const DEFAULT_TTR      = 60;
+
+    public const DEFAULT_TTR = 60;
 
     /**
      * @var string|null
@@ -60,8 +62,8 @@ class Job implements JobInterface
         $ttr = self::DEFAULT_TTR
     ) {
         $this->queue = $queue;
-        $this->body  = $body;
-        $this->id    = $id;
+        $this->body = $body;
+        $this->id = $id;
         $this->delay = (int)$delay;
         $this->setPriority($priority);
         $this->setTtr($ttr);

--- a/src/Job.php
+++ b/src/Job.php
@@ -8,9 +8,9 @@ namespace Phlib\JobQueue;
  */
 class Job implements JobInterface
 {
-    const DEFAULT_DELAY    = 0;
-    const DEFAULT_PRIORITY = 1024;
-    const DEFAULT_TTR      = 60;
+    public const DEFAULT_DELAY    = 0;
+    public const DEFAULT_PRIORITY = 1024;
+    public const DEFAULT_TTR      = 60;
 
     /**
      * @var string|null

--- a/src/Job.php
+++ b/src/Job.php
@@ -15,9 +15,9 @@ class Job implements JobInterface
     public const DEFAULT_TTR = 60;
 
     /**
-     * @var string|null
+     * @var string
      */
-    protected $queue = null;
+    protected $queue;
 
     /**
      * @var int|string|null
@@ -45,26 +45,21 @@ class Job implements JobInterface
     protected $body;
 
     /**
-     * Job constructor.
-     * @param string $queue
      * @param mixed $body
      * @param int|string|null $id
-     * @param int $delay
-     * @param int $priority
-     * @param int $ttr
      */
     public function __construct(
-        $queue,
+        string $queue,
         $body,
         $id = null,
-        $delay = self::DEFAULT_DELAY,
-        $priority = self::DEFAULT_PRIORITY,
-        $ttr = self::DEFAULT_TTR
+        int $delay = self::DEFAULT_DELAY,
+        int $priority = self::DEFAULT_PRIORITY,
+        int $ttr = self::DEFAULT_TTR
     ) {
         $this->queue = $queue;
         $this->body = $body;
         $this->id = $id;
-        $this->delay = (int)$delay;
+        $this->delay = $delay;
         $this->setPriority($priority);
         $this->setTtr($ttr);
     }
@@ -77,10 +72,7 @@ class Job implements JobInterface
         return $this->id;
     }
 
-    /**
-     * @return string
-     */
-    public function getQueue()
+    public function getQueue(): string
     {
         return $this->queue;
     }
@@ -93,37 +85,23 @@ class Job implements JobInterface
         return $this->body;
     }
 
-    /**
-     * @return int
-     */
-    public function getDelay()
+    public function getDelay(): int
     {
         return $this->delay;
     }
 
-    /**
-     * @return \DateTimeImmutable
-     */
-    public function getDatetimeDelay()
+    public function getDatetimeDelay(): \DateTimeImmutable
     {
         return (new \DateTimeImmutable())->setTimestamp(time() + $this->getDelay());
     }
 
-    /**
-     * @param int $value
-     * @return $this
-     */
-    public function setDelay($value)
+    public function setDelay(int $value): self
     {
         $this->delay = (int)$value;
         return $this;
     }
 
-    /**
-     * @param \DateTimeInterface $value
-     * @return $this
-     */
-    public function setDatetimeDelay(\DateTimeInterface $value)
+    public function setDatetimeDelay(\DateTimeInterface $value): self
     {
         $value = time() - $value->getTimestamp();
         if ($value < 0) {
@@ -133,39 +111,25 @@ class Job implements JobInterface
         return $this;
     }
 
-    /**
-     * @return int
-     */
-    public function getTtr()
+    public function getTtr(): int
     {
         return $this->ttr;
     }
 
-    /**
-     * @param int $value
-     * @return $this
-     */
-    public function setTtr($value)
+    public function setTtr(int $value): self
     {
-        $this->ttr = (int)$value;
+        $this->ttr = $value;
         return $this;
     }
 
-    /**
-     * @return int
-     */
-    public function getPriority()
+    public function getPriority(): int
     {
         return $this->priority;
     }
 
-    /**
-     * @param int $value
-     * @return $this
-     */
-    public function setPriority($value)
+    public function setPriority(int $value): self
     {
-        $this->priority = (int)$value;
+        $this->priority = $value;
         return $this;
     }
 }

--- a/src/JobInterface.php
+++ b/src/JobInterface.php
@@ -30,13 +30,11 @@ interface JobInterface
     public function getDatetimeDelay();
 
     /**
-     * @param int $value
      * @return $this
      */
-    public function setDelay($value);
+    public function setDelay(int $value);
 
     /**
-     * @param \DateTimeInterface $value
      * @return $this
      */
     public function setDatetimeDelay(\DateTimeInterface $value);
@@ -47,10 +45,9 @@ interface JobInterface
     public function getTtr();
 
     /**
-     * @param int $value
      * @return $this
      */
-    public function setTtr($value);
+    public function setTtr(int $value);
 
     /**
      * @return int
@@ -58,8 +55,7 @@ interface JobInterface
     public function getPriority();
 
     /**
-     * @param int $value
      * @return $this
      */
-    public function setPriority($value);
+    public function setPriority(int $value);
 }

--- a/src/JobQueueInterface.php
+++ b/src/JobQueueInterface.php
@@ -5,41 +5,32 @@ namespace Phlib\JobQueue;
 interface JobQueueInterface
 {
     /**
-     * @param string $queue
      * @param mixed $data
      * @param int|string|null $id
-     * @param int $delay
-     * @param int $priority
-     * @param int $ttr
-     * @return JobInterface
      */
-    public function createJob($queue, $data, $id, $delay, $priority, $ttr);
+    public function createJob(string $queue, $data, $id, int $delay, int $priority, int $ttr): JobInterface;
 
     /**
-     * @param JobInterface $job
      * @return $this
      */
     public function put(JobInterface $job);
 
     /**
-     * @param string $queue
      * @return JobInterface
      */
-    public function retrieve($queue);
+    public function retrieve(string $queue);
 
     /**
-     * @param JobInterface $job
      * @return mixed
      */
     public function markAsComplete(JobInterface $job);
 
     /**
-     * @param JobInterface $job
+     * @return mixed
      */
     public function markAsIncomplete(JobInterface $job);
 
     /**
-     * @param JobInterface $job
      * @return mixed
      */
     public function markAsError(JobInterface $job);

--- a/src/JobQueueInterface.php
+++ b/src/JobQueueInterface.php
@@ -11,27 +11,28 @@ interface JobQueueInterface
     public function createJob(string $queue, $data, $id, int $delay, int $priority, int $ttr): JobInterface;
 
     /**
+     * @todo php74 return type self
      * @return $this
      */
     public function put(JobInterface $job);
 
-    /**
-     * @return JobInterface
-     */
-    public function retrieve(string $queue);
+    public function retrieve(string $queue): ?JobInterface;
 
     /**
-     * @return mixed
+     * @todo php74 return type self
+     * @return $this
      */
     public function markAsComplete(JobInterface $job);
 
     /**
-     * @return mixed
+     * @todo php74 return type self
+     * @return $this
      */
     public function markAsIncomplete(JobInterface $job);
 
     /**
-     * @return mixed
+     * @todo php74 return type self
+     * @return $this
      */
     public function markAsError(JobInterface $job);
 }

--- a/src/Scheduler/DbScheduler.php
+++ b/src/Scheduler/DbScheduler.php
@@ -27,7 +27,6 @@ class DbScheduler implements SchedulerInterface
     private $minimumPickup;
 
     /**
-     * @param Adapter $adapter
      * @param integer $maximumDelay
      * @param integer $minimumPickup
      */
@@ -38,18 +37,12 @@ class DbScheduler implements SchedulerInterface
         $this->minimumPickup = $minimumPickup;
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function shouldBeScheduled($delay)
+    public function shouldBeScheduled($delay): bool
     {
         return $delay > $this->maximumDelay;
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function store(JobInterface $job)
+    public function store(JobInterface $job): bool
     {
         $dbTimestampFormat = 'Y-m-d H:i:s';
         return (bool)$this->insert([
@@ -63,7 +56,7 @@ class DbScheduler implements SchedulerInterface
     }
 
     /**
-     * @inheritdoc
+     * @return array|false
      */
     public function retrieve()
     {
@@ -104,9 +97,9 @@ class DbScheduler implements SchedulerInterface
     }
 
     /**
-     * @inheritdoc
+     * @param int|string $jobId
      */
-    public function remove($jobId)
+    public function remove($jobId): bool
     {
         $table = $this->adapter->quote()->identifier('scheduled_queue');
         $sql = "DELETE FROM {$table} WHERE id = ?";
@@ -116,11 +109,7 @@ class DbScheduler implements SchedulerInterface
             ->rowCount();
     }
 
-    /**
-     * @param array $data
-     * @return int
-     */
-    protected function insert(array $data)
+    protected function insert(array $data): int
     {
         $table = $this->adapter->quote()->identifier('scheduled_queue');
         $fields = implode(', ', array_keys($data));

--- a/src/Scheduler/DbScheduler.php
+++ b/src/Scheduler/DbScheduler.php
@@ -33,8 +33,8 @@ class DbScheduler implements SchedulerInterface
      */
     public function __construct(Adapter $adapter, $maximumDelay = 300, $minimumPickup = 600)
     {
-        $this->adapter       = $adapter;
-        $this->maximumDelay  = $maximumDelay;
+        $this->adapter = $adapter;
+        $this->maximumDelay = $maximumDelay;
         $this->minimumPickup = $minimumPickup;
     }
 
@@ -52,13 +52,13 @@ class DbScheduler implements SchedulerInterface
     public function store(JobInterface $job)
     {
         $dbTimestampFormat = 'Y-m-d H:i:s';
-        return (boolean)$this->insert([
-            'tube'         => $job->getQueue(),
-            'data'         => serialize($job->getBody()),
+        return (bool)$this->insert([
+            'tube' => $job->getQueue(),
+            'data' => serialize($job->getBody()),
             'scheduled_ts' => $job->getDatetimeDelay()->format($dbTimestampFormat),
-            'priority'     => $job->getPriority(),
-            'ttr'          => $job->getTtr(),
-            'create_ts'    => date($dbTimestampFormat)
+            'priority' => $job->getPriority(),
+            'ttr' => $job->getTtr(),
+            'create_ts' => date($dbTimestampFormat),
         ]);
     }
 
@@ -67,7 +67,7 @@ class DbScheduler implements SchedulerInterface
      */
     public function retrieve()
     {
-        $sql = "
+        $sql = '
             UPDATE scheduled_queue SET
                 picked_by = CONNECTION_ID(),
                 picked_ts = NOW()
@@ -76,28 +76,30 @@ class DbScheduler implements SchedulerInterface
                 picked_by IS NULL
             ORDER BY
                 scheduled_ts DESC
-            LIMIT 1";
-        $stmt = $this->adapter->query($sql, [':minimumPickup' => $this->minimumPickup]);
+            LIMIT 1';
+        $stmt = $this->adapter->query($sql, [
+            ':minimumPickup' => $this->minimumPickup,
+        ]);
         if ($stmt->rowCount() == 0) {
             return false; // no jobs
         }
 
-        $sql = "SELECT * FROM `scheduled_queue` WHERE picked_by = CONNECTION_ID() LIMIT 1";
+        $sql = 'SELECT * FROM `scheduled_queue` WHERE picked_by = CONNECTION_ID() LIMIT 1';
         $row = $this->adapter->query($sql)->fetch(\PDO::FETCH_ASSOC);
 
         $scheduledTime = strtotime($row['scheduled_ts']);
-        $delay         = $scheduledTime - time();
+        $delay = $scheduledTime - time();
         if ($delay < 0) {
             $delay = 0;
         }
 
         return [
-            'id'       => $row['id'],
-            'queue'    => $row['tube'],
-            'data'     => unserialize($row['data']),
-            'delay'    => $delay,
+            'id' => $row['id'],
+            'queue' => $row['tube'],
+            'data' => unserialize($row['data']),
+            'delay' => $delay,
             'priority' => $row['priority'],
-            'ttr'      => $row['ttr']
+            'ttr' => $row['ttr'],
         ];
     }
 
@@ -107,7 +109,7 @@ class DbScheduler implements SchedulerInterface
     public function remove($jobId)
     {
         $table = $this->adapter->quote()->identifier('scheduled_queue');
-        $sql   = "DELETE FROM $table WHERE id = ?";
+        $sql = "DELETE FROM {$table} WHERE id = ?";
 
         return (bool)$this->adapter
             ->query($sql, [$jobId])
@@ -120,10 +122,10 @@ class DbScheduler implements SchedulerInterface
      */
     protected function insert(array $data)
     {
-        $table        = $this->adapter->quote()->identifier('scheduled_queue');
-        $fields       = implode(', ', array_keys($data));
+        $table = $this->adapter->quote()->identifier('scheduled_queue');
+        $fields = implode(', ', array_keys($data));
         $placeholders = implode(', ', array_fill(0, count($data), '?'));
-        $sql          = "INSERT INTO $table ($fields) VALUES ($placeholders)";
+        $sql = "INSERT INTO {$table} ({$fields}) VALUES ({$placeholders})";
 
         return $this->adapter
             ->query($sql, array_values($data))

--- a/src/Scheduler/SchedulerInterface.php
+++ b/src/Scheduler/SchedulerInterface.php
@@ -10,17 +10,9 @@ use Phlib\JobQueue\JobInterface;
  */
 interface SchedulerInterface
 {
-    /**
-     * @param integer $delay
-     * @return boolean
-     */
-    public function shouldBeScheduled($delay);
+    public function shouldBeScheduled(int $delay): bool;
 
-    /**
-     * @param JobInterface $job
-     * @return boolean
-     */
-    public function store(JobInterface $job);
+    public function store(JobInterface $job): bool;
 
     /**
      * @return array|false
@@ -29,7 +21,6 @@ interface SchedulerInterface
 
     /**
      * @param int|string $jobId
-     * @return bool
      */
-    public function remove($jobId);
+    public function remove($jobId): bool;
 }

--- a/tests/AwsSqs/JobQueueTest.php
+++ b/tests/AwsSqs/JobQueueTest.php
@@ -7,6 +7,7 @@ use Aws\Sqs\SqsClient;
 use Phlib\JobQueue\AwsSqs\JobQueue;
 use Phlib\JobQueue\Job;
 use Phlib\JobQueue\Scheduler\SchedulerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
@@ -113,7 +114,7 @@ class JobQueueTest extends TestCase
         $jobQueue->markAsError($job);
     }
 
-    private function mockAwsResult(array $valueMap): \PHPUnit_Framework_MockObject_MockObject
+    private function mockAwsResult(array $valueMap): MockObject
     {
         $result = $this->createMock(Result::class);
         $result->method('get')->will($this->returnValueMap($valueMap));

--- a/tests/AwsSqs/JobQueueTest.php
+++ b/tests/AwsSqs/JobQueueTest.php
@@ -15,8 +15,8 @@ class JobQueueTest extends TestCase
     public function testCreateJob()
     {
         $queuePrefix = 'prefix-';
-        $sqsClient = $this->getMockBuilder(SqsClient::class)->disableOriginalConstructor()->getMock();
-        $scheduler = $this->getMock(SchedulerInterface::class);
+        $sqsClient = $this->createMock(SqsClient::class);
+        $scheduler = $this->createMock(SchedulerInterface::class);
         $jobQueue = new JobQueue($sqsClient, $scheduler, $queuePrefix);
 
         $queue = 'mockQueue';
@@ -41,7 +41,7 @@ class JobQueueTest extends TestCase
     public function testRetrieve()
     {
         $sqsClient = $this->prophesize(SqsClient::class);
-        $scheduler = $this->getMock(SchedulerInterface::class);
+        $scheduler = $this->createMock(SchedulerInterface::class);
 
         $queuePrefix = 'prefix-';
         $queue = 'mockQueue';
@@ -64,7 +64,7 @@ class JobQueueTest extends TestCase
     public function testMarkAsErrorWithPrefix()
     {
         $sqsClient = $this->prophesize(SqsClient::class);
-        $scheduler = $this->getMock(SchedulerInterface::class);
+        $scheduler = $this->createMock(SchedulerInterface::class);
 
         $queuePrefix = 'prefix-';
         $queue = 'mockQueue';
@@ -115,7 +115,7 @@ class JobQueueTest extends TestCase
 
     private function mockAwsResult(array $valueMap)
     {
-        $result = $this->getMock(Result::class);
+        $result = $this->createMock(Result::class);
         $result->method('get')->will($this->returnValueMap($valueMap));
         $result->method('search')->will($this->returnValueMap($valueMap));
         return $result;

--- a/tests/AwsSqs/JobQueueTest.php
+++ b/tests/AwsSqs/JobQueueTest.php
@@ -12,7 +12,7 @@ use Prophecy\Argument;
 
 class JobQueueTest extends TestCase
 {
-    public function testCreateJob()
+    public function testCreateJob(): void
     {
         $queuePrefix = 'prefix-';
         $sqsClient = $this->createMock(SqsClient::class);
@@ -38,7 +38,7 @@ class JobQueueTest extends TestCase
         $this->assertEquals($ttr, $job->getTtr());
     }
 
-    public function testRetrieve()
+    public function testRetrieve(): void
     {
         $sqsClient = $this->prophesize(SqsClient::class);
         $scheduler = $this->createMock(SchedulerInterface::class);
@@ -61,7 +61,7 @@ class JobQueueTest extends TestCase
         $jobQueue->retrieve($queue);
     }
 
-    public function testMarkAsErrorWithPrefix()
+    public function testMarkAsErrorWithPrefix(): void
     {
         $sqsClient = $this->prophesize(SqsClient::class);
         $scheduler = $this->createMock(SchedulerInterface::class);
@@ -113,7 +113,7 @@ class JobQueueTest extends TestCase
         $jobQueue->markAsError($job);
     }
 
-    private function mockAwsResult(array $valueMap)
+    private function mockAwsResult(array $valueMap): \PHPUnit_Framework_MockObject_MockObject
     {
         $result = $this->createMock(Result::class);
         $result->method('get')->will($this->returnValueMap($valueMap));

--- a/tests/AwsSqs/JobQueueTest.php
+++ b/tests/AwsSqs/JobQueueTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Phlib\JobQueue\Tests\AwsSqs;
 
 use Aws\Result;
@@ -19,7 +20,9 @@ class JobQueueTest extends TestCase
         $jobQueue = new JobQueue($sqsClient, $scheduler, $queuePrefix);
 
         $queue = 'mockQueue';
-        $data = ['userId' => 123];
+        $data = [
+            'userId' => 123,
+        ];
         $id = 456;
         $delay = 75;
         $priority = 256;
@@ -45,7 +48,9 @@ class JobQueueTest extends TestCase
         $queueUrl = 'mockQueueUrl';
 
         // We expect to fetch the URL for the queue with the prefix
-        $sqsClient->getQueueUrl(['QueueName' => $queuePrefix . $queue])
+        $sqsClient->getQueueUrl([
+            'QueueName' => $queuePrefix . $queue,
+        ])
             ->shouldBeCalledOnce()
             ->willReturn($this->mockAwsResult([['QueueUrl', $queueUrl]]));
 
@@ -68,14 +73,17 @@ class JobQueueTest extends TestCase
         $deadletterQueueUrl = 'mockDeadletterQueueUrl';
         $jobId = 123;
 
-
         // We expect to fetch the URL for the queue with the prefix
-        $sqsClient->getQueueUrl(['QueueName' => $queuePrefix . $queue])
+        $sqsClient->getQueueUrl([
+            'QueueName' => $queuePrefix . $queue,
+        ])
             ->shouldBeCalledOnce()
             ->willReturn($this->mockAwsResult([['QueueUrl', $queueUrl]]));
 
         // We expect to fetch the URL for the deadletter queue
-        $sqsClient->getQueueUrl(['QueueName' => $deadLetterQueue])
+        $sqsClient->getQueueUrl([
+            'QueueName' => $deadLetterQueue,
+        ])
             ->shouldBeCalledOnce()
             ->willReturn($this->mockAwsResult([['QueueUrl', $deadletterQueueUrl]]));
 
@@ -83,13 +91,18 @@ class JobQueueTest extends TestCase
         $sqsClient->getQueueAttributes(Argument::withEntry('QueueUrl', $queueUrl))
             ->shouldBeCalledOnce()
             ->willReturn(
-                $this->mockAwsResult([
-                    ['Attributes.RedrivePolicy', json_encode(['deadLetterTargetArn' => "arn:{$deadLetterQueue}"])]
-                ])
+                $this->mockAwsResult([[
+                    'Attributes.RedrivePolicy', json_encode([
+                        'deadLetterTargetArn' => "arn:{$deadLetterQueue}",
+                    ]),
+                ]])
             );
 
         // We expect to remove the job from the main queue
-        $sqsClient->deleteMessage(['QueueUrl' => $queueUrl, 'ReceiptHandle' => $jobId])
+        $sqsClient->deleteMessage([
+            'QueueUrl' => $queueUrl,
+            'ReceiptHandle' => $jobId,
+        ])
             ->shouldBeCalledOnce();
 
         // We expect to push a job to the deadletter queue

--- a/tests/Beanstalk/JobQueueTest.php
+++ b/tests/Beanstalk/JobQueueTest.php
@@ -5,21 +5,24 @@ namespace Phlib\JobQueue\Tests\Beanstalk;
 use Phlib\Beanstalk\Connection\ConnectionInterface;
 use Phlib\JobQueue\Beanstalk\JobFactory;
 use Phlib\JobQueue\Beanstalk\JobQueue;
+use Phlib\JobQueue\Exception\InvalidArgumentException;
+use Phlib\JobQueue\Exception\JobRuntimeException;
 use Phlib\JobQueue\Job;
 use Phlib\JobQueue\JobInterface;
 use Phlib\JobQueue\JobQueueInterface;
 use Phlib\JobQueue\Scheduler\SchedulerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class JobQueueTest extends TestCase
 {
     /**
-     * @var ConnectionInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ConnectionInterface|MockObject
      */
     protected $beanstalk;
 
     /**
-     * @var SchedulerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var SchedulerInterface|MockObject
      */
     protected $scheduler;
 
@@ -112,22 +115,20 @@ class JobQueueTest extends TestCase
         static::assertFalse($this->jobQueue->retrieve('testQueue'));
     }
 
-    /**
-     * @expectedException \Phlib\JobQueue\Exception\InvalidArgumentException
-     */
     public function testRetrieveWithBadlyFormedBeanstalkData(): void
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $this->beanstalk->expects(static::once())
             ->method('reserve')
             ->willReturn([]);
         $this->jobQueue->retrieve('testQueue');
     }
 
-    /**
-     * @expectedException \Phlib\JobQueue\Exception\JobRuntimeException
-     */
     public function testRetrieveWithBadlyFormedJobBody(): void
     {
+        $this->expectException(JobRuntimeException::class);
+
         $this->beanstalk->expects(static::once())
             ->method('reserve')
             ->willReturn([

--- a/tests/Beanstalk/JobQueueTest.php
+++ b/tests/Beanstalk/JobQueueTest.php
@@ -69,7 +69,7 @@ class JobQueueTest extends TestCase
         $job->method('getDelay')
             ->willReturn(rand(1, 100));
 
-        static::assertEquals($jobId, $this->jobQueue->put($job));
+        $this->jobQueue->put($job);
     }
 
     public function testPutForProlongedJobCallsScheduler(): void
@@ -88,7 +88,7 @@ class JobQueueTest extends TestCase
             ->with($job)
             ->willReturn($jobId);
 
-        static::assertEquals($jobId, $this->jobQueue->put($job));
+        $this->jobQueue->put($job);
     }
 
     public function testRetrieveSuccessfully(): void
@@ -112,7 +112,7 @@ class JobQueueTest extends TestCase
         $this->beanstalk->expects(static::once())
             ->method('reserve')
             ->willReturn(false);
-        static::assertFalse($this->jobQueue->retrieve('testQueue'));
+        static::assertNull($this->jobQueue->retrieve('testQueue'));
     }
 
     public function testRetrieveWithBadlyFormedBeanstalkData(): void

--- a/tests/Beanstalk/JobQueueTest.php
+++ b/tests/Beanstalk/JobQueueTest.php
@@ -46,24 +46,24 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
 
     public function testIsInstanceOfJobQueueInterface()
     {
-        $this->assertInstanceOf(JobQueueInterface::class, $this->jobQueue);
+        static::assertInstanceOf(JobQueueInterface::class, $this->jobQueue);
     }
 
     public function testPutForImmediateJobCallsBeanstalk()
     {
         $jobId = 123;
-        $this->scheduler->expects($this->any())
+        $this->scheduler->expects(static::any())
             ->method('shouldBeScheduled')
             ->willReturn(false);
-        $this->beanstalk->expects($this->any())
+        $this->beanstalk->expects(static::any())
             ->method('useTube')
-            ->will($this->returnSelf());
-        $this->beanstalk->expects($this->once())
+            ->will(static::returnSelf());
+        $this->beanstalk->expects(static::once())
             ->method('put')
-            ->will($this->returnValue($jobId));
+            ->will(static::returnValue($jobId));
 
         $job = $this->getMock(JobInterface::class);
-        $this->assertEquals($jobId, $this->jobQueue->put($job));
+        static::assertEquals($jobId, $this->jobQueue->put($job));
     }
 
     public function testPutForProlongedJobCallsScheduler()
@@ -71,33 +71,33 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
         $jobId = 123;
         $job   = $this->getMock(JobInterface::class);
 
-        $this->scheduler->expects($this->any())
+        $this->scheduler->expects(static::any())
             ->method('shouldBeScheduled')
             ->willReturn(true);
-        $this->scheduler->expects($this->once())
+        $this->scheduler->expects(static::once())
             ->method('store')
-            ->with($this->equalTo($job))
-            ->will($this->returnValue($jobId));
+            ->with(static::equalTo($job))
+            ->will(static::returnValue($jobId));
 
-        $this->assertEquals($jobId, $this->jobQueue->put($job));
+        static::assertEquals($jobId, $this->jobQueue->put($job));
     }
 
     public function testRetrieveSuccessfully()
     {
         $jobId = 123;
         $body  = ['queue' => 'TestQueue', 'body' => 'TestBody'];
-        $this->beanstalk->expects($this->any())
+        $this->beanstalk->expects(static::any())
             ->method('reserve')
-            ->will($this->returnValue(['id' => $jobId, 'body' => serialize($body)]));
-        $this->assertEquals($jobId, $this->jobQueue->retrieve('testQueue')->getId());
+            ->will(static::returnValue(['id' => $jobId, 'body' => serialize($body)]));
+        static::assertEquals($jobId, $this->jobQueue->retrieve('testQueue')->getId());
     }
 
     public function testRetrieveWhenNoJobsAvailable()
     {
-        $this->beanstalk->expects($this->any())
+        $this->beanstalk->expects(static::any())
             ->method('reserve')
-            ->will($this->returnValue(false));
-        $this->assertFalse($this->jobQueue->retrieve('testQueue'));
+            ->will(static::returnValue(false));
+        static::assertFalse($this->jobQueue->retrieve('testQueue'));
     }
 
     /**
@@ -105,9 +105,9 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
      */
     public function testRetrieveWithBadlyFormedBeanstalkData()
     {
-        $this->beanstalk->expects($this->any())
+        $this->beanstalk->expects(static::any())
             ->method('reserve')
-            ->will($this->returnValue([]));
+            ->will(static::returnValue([]));
         $this->jobQueue->retrieve('testQueue');
     }
 
@@ -116,9 +116,9 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
      */
     public function testRetrieveWithBadlyFormedJobBody()
     {
-        $this->beanstalk->expects($this->any())
+        $this->beanstalk->expects(static::any())
             ->method('reserve')
-            ->will($this->returnValue(['id' => 234, 'body' => serialize('SomeStuffHere')]));
+            ->will(static::returnValue(['id' => 234, 'body' => serialize('SomeStuffHere')]));
         $this->jobQueue->retrieve('testQueue');
     }
 
@@ -129,11 +129,11 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
     public function testJobDataMaintainsExpectedType($jobData)
     {
         $package = JobFactory::serializeBody(new Job('TestQueue', $jobData));
-        $this->beanstalk->expects($this->any())
+        $this->beanstalk->expects(static::any())
             ->method('reserve')
-            ->will($this->returnValue(['id' => 234, 'body' => $package]));
+            ->will(static::returnValue(['id' => 234, 'body' => $package]));
         $job = $this->jobQueue->retrieve('TestQueue');
-        $this->assertEquals($jobData, $job->getBody());
+        static::assertEquals($jobData, $job->getBody());
     }
 
     public function jobDataMaintainsExpectedTypeDataProvider()
@@ -154,12 +154,12 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
     {
         $jobId = 123;
         $job = $this->getMock(JobInterface::class);
-        $job->expects($this->any())
+        $job->expects(static::any())
             ->method('getId')
-            ->will($this->returnValue($jobId));
-        $this->beanstalk->expects($this->once())
+            ->will(static::returnValue($jobId));
+        $this->beanstalk->expects(static::once())
             ->method('delete')
-            ->with($this->equalTo($jobId));
+            ->with(static::equalTo($jobId));
         $this->jobQueue->markAsComplete($job);
     }
 
@@ -167,18 +167,18 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
     {
         $jobId = 123;
         $job = $this->getMock(JobInterface::class);
-        $job->expects($this->any())
+        $job->expects(static::any())
             ->method('getId')
-            ->will($this->returnValue($jobId));
-        $this->scheduler->expects($this->any())
+            ->will(static::returnValue($jobId));
+        $this->scheduler->expects(static::any())
             ->method('shouldBeScheduled')
-            ->will($this->returnValue(false));
-        $this->beanstalk->expects($this->any())
+            ->will(static::returnValue(false));
+        $this->beanstalk->expects(static::any())
             ->method('useTube')
-            ->will($this->returnSelf());
-        $this->beanstalk->expects($this->once())
+            ->will(static::returnSelf());
+        $this->beanstalk->expects(static::once())
             ->method('release')
-            ->with($this->equalTo($jobId));
+            ->with(static::equalTo($jobId));
         $this->jobQueue->markAsIncomplete($job);
     }
 
@@ -186,15 +186,15 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
     {
         $jobId = 123;
         $job = $this->getMock(JobInterface::class);
-        $job->expects($this->any())
+        $job->expects(static::any())
             ->method('getId')
-            ->will($this->returnValue($jobId));
-        $this->scheduler->expects($this->any())
+            ->will(static::returnValue($jobId));
+        $this->scheduler->expects(static::any())
             ->method('shouldBeScheduled')
-            ->will($this->returnValue(true));
-        $this->scheduler->expects($this->once())
+            ->will(static::returnValue(true));
+        $this->scheduler->expects(static::once())
             ->method('store')
-            ->with($this->equalTo($job));
+            ->with(static::equalTo($job));
         $this->jobQueue->markAsIncomplete($job);
     }
 
@@ -202,12 +202,12 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
     {
         $jobId = 123;
         $job = $this->getMock(JobInterface::class);
-        $job->expects($this->any())
+        $job->expects(static::any())
             ->method('getId')
-            ->will($this->returnValue($jobId));
-        $this->beanstalk->expects($this->once())
+            ->will(static::returnValue($jobId));
+        $this->beanstalk->expects(static::once())
             ->method('bury')
-            ->with($this->equalTo($jobId));
+            ->with(static::equalTo($jobId));
         $this->jobQueue->markAsError($job);
     }
 }

--- a/tests/Beanstalk/JobQueueTest.php
+++ b/tests/Beanstalk/JobQueueTest.php
@@ -5,6 +5,8 @@ namespace Phlib\JobQueue\Tests\Beanstalk;
 use Phlib\JobQueue\Beanstalk\JobFactory;
 use Phlib\JobQueue\Beanstalk\JobQueue;
 use Phlib\JobQueue\Job;
+use Phlib\JobQueue\JobInterface;
+use Phlib\JobQueue\JobQueueInterface;
 use Phlib\JobQueue\Scheduler\SchedulerInterface;
 use Phlib\Beanstalk\Connection\ConnectionInterface;
 
@@ -29,8 +31,8 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->beanstalk = $this->getMock('\Phlib\Beanstalk\Connection\ConnectionInterface');
-        $this->scheduler = $this->getMock('\Phlib\JobQueue\Scheduler\SchedulerInterface');
+        $this->beanstalk = $this->getMock(ConnectionInterface::class);
+        $this->scheduler = $this->getMock(SchedulerInterface::class);
         $this->jobQueue  = new JobQueue($this->beanstalk, $this->scheduler);
     }
 
@@ -44,7 +46,7 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
 
     public function testIsInstanceOfJobQueueInterface()
     {
-        $this->assertInstanceOf('\Phlib\JobQueue\JobQueueInterface', $this->jobQueue);
+        $this->assertInstanceOf(JobQueueInterface::class, $this->jobQueue);
     }
 
     public function testPutForImmediateJobCallsBeanstalk()
@@ -60,14 +62,14 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
             ->method('put')
             ->will($this->returnValue($jobId));
 
-        $job = $this->getMock('\Phlib\JobQueue\JobInterface');
+        $job = $this->getMock(JobInterface::class);
         $this->assertEquals($jobId, $this->jobQueue->put($job));
     }
 
     public function testPutForProlongedJobCallsScheduler()
     {
         $jobId = 123;
-        $job   = $this->getMock('\Phlib\JobQueue\JobInterface');
+        $job   = $this->getMock(JobInterface::class);
 
         $this->scheduler->expects($this->any())
             ->method('shouldBeScheduled')
@@ -151,7 +153,7 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
     public function testMarkAsCompleteDeletesBeanstalkJob()
     {
         $jobId = 123;
-        $job = $this->getMock('\Phlib\JobQueue\JobInterface');
+        $job = $this->getMock(JobInterface::class);
         $job->expects($this->any())
             ->method('getId')
             ->will($this->returnValue($jobId));
@@ -164,7 +166,7 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
     public function testMarkAsIncompleteReleasesBeanstalkJobWhenDelayIsMoreImmediate()
     {
         $jobId = 123;
-        $job = $this->getMock('\Phlib\JobQueue\JobInterface');
+        $job = $this->getMock(JobInterface::class);
         $job->expects($this->any())
             ->method('getId')
             ->will($this->returnValue($jobId));
@@ -183,7 +185,7 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
     public function testMarkAsIncompleteReleasesBeanstalkJobWhenDelayIsMoreProlonged()
     {
         $jobId = 123;
-        $job = $this->getMock('\Phlib\JobQueue\JobInterface');
+        $job = $this->getMock(JobInterface::class);
         $job->expects($this->any())
             ->method('getId')
             ->will($this->returnValue($jobId));
@@ -199,7 +201,7 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
     public function testMarkAsErrorBuriesBeanstalkJob()
     {
         $jobId = 123;
-        $job = $this->getMock('\Phlib\JobQueue\JobInterface');
+        $job = $this->getMock(JobInterface::class);
         $job->expects($this->any())
             ->method('getId')
             ->will($this->returnValue($jobId));

--- a/tests/Beanstalk/JobQueueTest.php
+++ b/tests/Beanstalk/JobQueueTest.php
@@ -2,14 +2,13 @@
 
 namespace Phlib\JobQueue\Tests\Beanstalk;
 
+use Phlib\Beanstalk\Connection\ConnectionInterface;
 use Phlib\JobQueue\Beanstalk\JobFactory;
 use Phlib\JobQueue\Beanstalk\JobQueue;
 use Phlib\JobQueue\Job;
 use Phlib\JobQueue\JobInterface;
 use Phlib\JobQueue\JobQueueInterface;
 use Phlib\JobQueue\Scheduler\SchedulerInterface;
-use Phlib\Beanstalk\Connection\ConnectionInterface;
-
 
 class JobQueueTest extends \PHPUnit_Framework_TestCase
 {
@@ -33,12 +32,12 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
         parent::setUp();
         $this->beanstalk = $this->getMock(ConnectionInterface::class);
         $this->scheduler = $this->getMock(SchedulerInterface::class);
-        $this->jobQueue  = new JobQueue($this->beanstalk, $this->scheduler);
+        $this->jobQueue = new JobQueue($this->beanstalk, $this->scheduler);
     }
 
     public function tearDown()
     {
-        $this->jobQueue  = null;
+        $this->jobQueue = null;
         $this->scheduler = null;
         $this->beanstalk = null;
         parent::tearDown();
@@ -69,7 +68,7 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
     public function testPutForProlongedJobCallsScheduler()
     {
         $jobId = 123;
-        $job   = $this->getMock(JobInterface::class);
+        $job = $this->getMock(JobInterface::class);
 
         $this->scheduler->expects(static::any())
             ->method('shouldBeScheduled')
@@ -85,10 +84,16 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
     public function testRetrieveSuccessfully()
     {
         $jobId = 123;
-        $body  = ['queue' => 'TestQueue', 'body' => 'TestBody'];
+        $body = [
+            'queue' => 'TestQueue',
+            'body' => 'TestBody',
+        ];
         $this->beanstalk->expects(static::any())
             ->method('reserve')
-            ->will(static::returnValue(['id' => $jobId, 'body' => serialize($body)]));
+            ->will(static::returnValue([
+                'id' => $jobId,
+                'body' => serialize($body),
+            ]));
         static::assertEquals($jobId, $this->jobQueue->retrieve('testQueue')->getId());
     }
 
@@ -118,7 +123,14 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
     {
         $this->beanstalk->expects(static::any())
             ->method('reserve')
+<<<<<<< HEAD
             ->will(static::returnValue(['id' => 234, 'body' => serialize('SomeStuffHere')]));
+=======
+            ->will($this->returnValue([
+                'id' => 234,
+                'body' => serialize('SomeStuffHere'),
+            ]));
+>>>>>>> 56dfb1d (Add EasyCodingStandard)
         $this->jobQueue->retrieve('testQueue');
     }
 
@@ -131,7 +143,14 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
         $package = JobFactory::serializeBody(new Job('TestQueue', $jobData));
         $this->beanstalk->expects(static::any())
             ->method('reserve')
+<<<<<<< HEAD
             ->will(static::returnValue(['id' => 234, 'body' => $package]));
+=======
+            ->will($this->returnValue([
+                'id' => 234,
+                'body' => $package,
+            ]));
+>>>>>>> 56dfb1d (Add EasyCodingStandard)
         $job = $this->jobQueue->retrieve('TestQueue');
         static::assertEquals($jobData, $job->getBody());
     }
@@ -139,14 +158,17 @@ class JobQueueTest extends \PHPUnit_Framework_TestCase
     public function jobDataMaintainsExpectedTypeDataProvider()
     {
         return [
-            [['foo' => 'bar', 'bar' => 'baz']],
+            [[
+                'foo' => 'bar',
+                'bar' => 'baz',
+            ]],
             ['SomeStringData'],
             [123],
             [123.34],
             // [null], // <-- null not accepted
             [[]],
             [false],
-            [true]
+            [true],
         ];
     }
 

--- a/tests/Command/WorkerCommandMock.php
+++ b/tests/Command/WorkerCommandMock.php
@@ -9,16 +9,24 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class WorkerCommandMock extends WorkerCommand
 {
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $queue = 'mockQueue';
 
-    /** @var JobQueueInterface */
+    /**
+     * @var JobQueueInterface
+     */
     protected $jobQueue;
 
-    /** @var bool */
+    /**
+     * @var bool
+     */
     protected $runOnce;
 
-    /** @var bool */
+    /**
+     * @var bool
+     */
     protected $exitOnException = true;
 
     public function __construct(JobQueueInterface $jobQueue, $runOnce = true)

--- a/tests/Command/WorkerCommandMock.php
+++ b/tests/Command/WorkerCommandMock.php
@@ -36,19 +36,19 @@ class WorkerCommandMock extends WorkerCommand
         $this->runOnce = $runOnce;
     }
 
-    protected function work(JobInterface $job, InputInterface $input, OutputInterface $output)
+    protected function work(JobInterface $job, InputInterface $input, OutputInterface $output): void
     {
         if ($this->runOnce) {
             $this->continue = false;
         }
     }
 
-    public function shouldContinue($state)
+    public function shouldContinue(bool $state): void
     {
-        $this->continue = (bool)$state;
+        $this->continue = $state;
     }
 
-    protected function getJobQueue()
+    protected function getJobQueue(): JobQueueInterface
     {
         return $this->jobQueue;
     }

--- a/tests/Command/WorkerCommandTest.php
+++ b/tests/Command/WorkerCommandTest.php
@@ -7,10 +7,11 @@ require __DIR__ . '/WorkerCommandMock.php';
 use Phlib\JobQueue\Exception\InvalidArgumentException;
 use Phlib\JobQueue\JobInterface;
 use Phlib\JobQueue\JobQueueInterface;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class WorkerCommandTest extends \PHPUnit_Framework_TestCase
+class WorkerCommandTest extends TestCase
 {
     /**
      * @var JobQueueInterface|\PHPUnit_Framework_MockObject_MockObject
@@ -34,15 +35,21 @@ class WorkerCommandTest extends \PHPUnit_Framework_TestCase
         $this->input = $this->getMockForAbstractClass(InputInterface::class);
         $this->output = $this->getMockForAbstractClass(OutputInterface::class);
 
-        $this->input->expects(static::any())->method('getArgument')->willReturn('start');
+        $this->input->expects(static::once())
+            ->method('getArgument')
+            ->willReturn('start');
     }
 
     public function testRunCompletes()
     {
         // need to do at least one job to exit the loop of work
         $job = $this->getMockForAbstractClass(JobInterface::class);
-        $this->jobQueue->expects(static::at(0))->method('retrieve')->willReturn($job);
-        $this->jobQueue->expects(static::at(1))->method('retrieve')->willReturn(null);
+        $this->jobQueue->expects(static::at(0))
+            ->method('retrieve')
+            ->willReturn($job);
+        $this->jobQueue->expects(static::at(1))
+            ->method('retrieve')
+            ->willReturn(null);
         $command = new WorkerCommandMock($this->jobQueue);
         $code = $command->run($this->input, $this->output);
         static::assertEquals(0, $code);
@@ -53,7 +60,9 @@ class WorkerCommandTest extends \PHPUnit_Framework_TestCase
      */
     public function testLibraryExceptionOnRetrieve()
     {
-        $this->jobQueue->expects(static::any())->method('retrieve')->willThrowException(new InvalidArgumentException());
+        $this->jobQueue->expects(static::once())
+            ->method('retrieve')
+            ->willThrowException(new InvalidArgumentException());
 
         /** @var WorkerCommand|\PHPUnit_Framework_MockObject_MockObject $command */
         $command = new WorkerCommandMock($this->jobQueue);
@@ -66,9 +75,15 @@ class WorkerCommandTest extends \PHPUnit_Framework_TestCase
     public function testLibraryExceptionInMainLoop()
     {
         $job = $this->getMockForAbstractClass(JobInterface::class);
-        $this->jobQueue->expects(static::at(0))->method('retrieve')->willReturn($job);
-        $this->jobQueue->expects(static::at(1))->method('retrieve')->willReturn(null);
-        $this->jobQueue->expects(static::any())->method('markAsComplete')->willThrowException(new InvalidArgumentException());
+        $this->jobQueue->expects(static::at(0))
+            ->method('retrieve')
+            ->willReturn($job);
+        $this->jobQueue->expects(static::at(1))
+            ->method('retrieve')
+            ->willReturn(null);
+        $this->jobQueue->expects(static::once())
+            ->method('markAsComplete')
+            ->willThrowException(new InvalidArgumentException());
 
         /** @var WorkerCommand|\PHPUnit_Framework_MockObject_MockObject $command */
         $command = new WorkerCommandMock($this->jobQueue);

--- a/tests/Command/WorkerCommandTest.php
+++ b/tests/Command/WorkerCommandTest.php
@@ -28,18 +28,18 @@ class WorkerCommandTest extends \PHPUnit_Framework_TestCase
         $this->input    = $this->getMockForAbstractClass(InputInterface::class);
         $this->output   = $this->getMockForAbstractClass(OutputInterface::class);
 
-        $this->input->expects($this->any())->method('getArgument')->willReturn('start');
+        $this->input->expects(static::any())->method('getArgument')->willReturn('start');
     }
 
     public function testRunCompletes()
     {
         // need to do at least one job to exit the loop of work
         $job = $this->getMockForAbstractClass(JobInterface::class);
-        $this->jobQueue->expects($this->at(0))->method('retrieve')->willReturn($job);
-        $this->jobQueue->expects($this->at(1))->method('retrieve')->willReturn(null);
+        $this->jobQueue->expects(static::at(0))->method('retrieve')->willReturn($job);
+        $this->jobQueue->expects(static::at(1))->method('retrieve')->willReturn(null);
         $command = new WorkerCommandMock($this->jobQueue);
         $code = $command->run($this->input, $this->output);
-        $this->assertEquals(0, $code);
+        static::assertEquals(0, $code);
     }
 
     /**
@@ -47,7 +47,7 @@ class WorkerCommandTest extends \PHPUnit_Framework_TestCase
      */
     public function testLibraryExceptionOnRetrieve()
     {
-        $this->jobQueue->expects($this->any())->method('retrieve')->willThrowException(new InvalidArgumentException());
+        $this->jobQueue->expects(static::any())->method('retrieve')->willThrowException(new InvalidArgumentException());
 
         /** @var WorkerCommand|\PHPUnit_Framework_MockObject_MockObject $command */
         $command = new WorkerCommandMock($this->jobQueue);
@@ -60,9 +60,9 @@ class WorkerCommandTest extends \PHPUnit_Framework_TestCase
     public function testLibraryExceptionInMainLoop()
     {
         $job = $this->getMockForAbstractClass(JobInterface::class);
-        $this->jobQueue->expects($this->at(0))->method('retrieve')->willReturn($job);
-        $this->jobQueue->expects($this->at(1))->method('retrieve')->willReturn(null);
-        $this->jobQueue->expects($this->any())->method('markAsComplete')->willThrowException(new InvalidArgumentException());
+        $this->jobQueue->expects(static::at(0))->method('retrieve')->willReturn($job);
+        $this->jobQueue->expects(static::at(1))->method('retrieve')->willReturn(null);
+        $this->jobQueue->expects(static::any())->method('markAsComplete')->willThrowException(new InvalidArgumentException());
 
         /** @var WorkerCommand|\PHPUnit_Framework_MockObject_MockObject $command */
         $command = new WorkerCommandMock($this->jobQueue);

--- a/tests/Command/WorkerCommandTest.php
+++ b/tests/Command/WorkerCommandTest.php
@@ -7,6 +7,7 @@ require __DIR__ . '/WorkerCommandMock.php';
 use Phlib\JobQueue\Exception\InvalidArgumentException;
 use Phlib\JobQueue\JobInterface;
 use Phlib\JobQueue\JobQueueInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -14,17 +15,17 @@ use Symfony\Component\Console\Output\OutputInterface;
 class WorkerCommandTest extends TestCase
 {
     /**
-     * @var JobQueueInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var JobQueueInterface|MockObject
      */
     protected $jobQueue;
 
     /**
-     * @var InputInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var InputInterface|MockObject
      */
     protected $input;
 
     /**
-     * @var OutputInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var OutputInterface|MockObject
      */
     protected $output;
 
@@ -55,25 +56,23 @@ class WorkerCommandTest extends TestCase
         static::assertEquals(0, $code);
     }
 
-    /**
-     * @expectedException \Phlib\JobQueue\Exception\InvalidArgumentException
-     */
     public function testLibraryExceptionOnRetrieve(): void
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $this->jobQueue->expects(static::once())
             ->method('retrieve')
             ->willThrowException(new InvalidArgumentException());
 
-        /** @var WorkerCommand|\PHPUnit_Framework_MockObject_MockObject $command */
+        /** @var WorkerCommand|MockObject $command */
         $command = new WorkerCommandMock($this->jobQueue);
         $command->run($this->input, $this->output);
     }
 
-    /**
-     * @expectedException \Phlib\JobQueue\Exception\InvalidArgumentException
-     */
     public function testLibraryExceptionInMainLoop(): void
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $job = $this->getMockForAbstractClass(JobInterface::class);
         $this->jobQueue->expects(static::at(0))
             ->method('retrieve')
@@ -85,7 +84,7 @@ class WorkerCommandTest extends TestCase
             ->method('markAsComplete')
             ->willThrowException(new InvalidArgumentException());
 
-        /** @var WorkerCommand|\PHPUnit_Framework_MockObject_MockObject $command */
+        /** @var WorkerCommand|MockObject $command */
         $command = new WorkerCommandMock($this->jobQueue);
         $command->run($this->input, $this->output);
     }

--- a/tests/Command/WorkerCommandTest.php
+++ b/tests/Command/WorkerCommandTest.php
@@ -12,21 +12,27 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class WorkerCommandTest extends \PHPUnit_Framework_TestCase
 {
-    /** @var JobQueueInterface|\PHPUnit_Framework_MockObject_MockObject */
+    /**
+     * @var JobQueueInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
     protected $jobQueue;
 
-    /** @var InputInterface|\PHPUnit_Framework_MockObject_MockObject */
+    /**
+     * @var InputInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
     protected $input;
 
-    /** @var OutputInterface|\PHPUnit_Framework_MockObject_MockObject */
+    /**
+     * @var OutputInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
     protected $output;
 
     protected function setUp()
     {
         parent::setUp();
         $this->jobQueue = $this->getMockForAbstractClass(JobQueueInterface::class);
-        $this->input    = $this->getMockForAbstractClass(InputInterface::class);
-        $this->output   = $this->getMockForAbstractClass(OutputInterface::class);
+        $this->input = $this->getMockForAbstractClass(InputInterface::class);
+        $this->output = $this->getMockForAbstractClass(OutputInterface::class);
 
         $this->input->expects(static::any())->method('getArgument')->willReturn('start');
     }

--- a/tests/Command/WorkerCommandTest.php
+++ b/tests/Command/WorkerCommandTest.php
@@ -28,7 +28,7 @@ class WorkerCommandTest extends TestCase
      */
     protected $output;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->jobQueue = $this->getMockForAbstractClass(JobQueueInterface::class);
@@ -40,7 +40,7 @@ class WorkerCommandTest extends TestCase
             ->willReturn('start');
     }
 
-    public function testRunCompletes()
+    public function testRunCompletes(): void
     {
         // need to do at least one job to exit the loop of work
         $job = $this->getMockForAbstractClass(JobInterface::class);
@@ -58,7 +58,7 @@ class WorkerCommandTest extends TestCase
     /**
      * @expectedException \Phlib\JobQueue\Exception\InvalidArgumentException
      */
-    public function testLibraryExceptionOnRetrieve()
+    public function testLibraryExceptionOnRetrieve(): void
     {
         $this->jobQueue->expects(static::once())
             ->method('retrieve')
@@ -72,7 +72,7 @@ class WorkerCommandTest extends TestCase
     /**
      * @expectedException \Phlib\JobQueue\Exception\InvalidArgumentException
      */
-    public function testLibraryExceptionInMainLoop()
+    public function testLibraryExceptionInMainLoop(): void
     {
         $job = $this->getMockForAbstractClass(JobInterface::class);
         $this->jobQueue->expects(static::at(0))

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -8,12 +8,12 @@ use PHPUnit\Framework\TestCase;
 
 class JobTest extends TestCase
 {
-    public function testInstanceOfJobInterface()
+    public function testInstanceOfJobInterface(): void
     {
         static::assertInstanceOf(JobInterface::class, new Job('queue', 'body'));
     }
 
-    public function testEachProperty()
+    public function testEachProperty(): void
     {
         $data = [
             'queue' => 'testQueue',
@@ -36,14 +36,14 @@ class JobTest extends TestCase
         static::assertSame($data, $actual);
     }
 
-    public function testGetDatetimeDelayReturnsCorrectDateTime()
+    public function testGetDatetimeDelayReturnsCorrectDateTime(): void
     {
         $delay = 10;
         $job = new Job('queue', 'body', 'id', $delay);
         static::assertEquals(time() + $delay, $job->getDatetimeDelay()->getTimestamp());
     }
 
-    public function testSetDelay()
+    public function testSetDelay(): void
     {
         $delay = 10;
         $job = new Job('queue', 'body', 'id', 2000);
@@ -51,7 +51,7 @@ class JobTest extends TestCase
         static::assertEquals($delay, $job->getDelay());
     }
 
-    public function testSetTtr()
+    public function testSetTtr(): void
     {
         $ttr = 60;
         $job = new Job('queue', 'body', 'id', 10, 10, 2000);
@@ -59,7 +59,7 @@ class JobTest extends TestCase
         static::assertEquals($ttr, $job->getTtr());
     }
 
-    public function testSetPriority()
+    public function testSetPriority(): void
     {
         $priority = 100;
         $job = new Job('queue', 'body', 'id', 10, 2000);

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -9,7 +9,7 @@ class JobTest extends \PHPUnit_Framework_TestCase
 {
     public function testInstanceOfJobInterface()
     {
-        $this->assertInstanceOf(JobInterface::class, new Job('queue', 'body'));
+        static::assertInstanceOf(JobInterface::class, new Job('queue', 'body'));
     }
 
     public function testEachProperty()
@@ -32,14 +32,14 @@ class JobTest extends \PHPUnit_Framework_TestCase
             'priority' => $job->getPriority(),
             'ttr'      => $job->getTtr(),
         ];
-        $this->assertSame($data, $actual);
+        static::assertSame($data, $actual);
     }
 
     public function testGetDatetimeDelayReturnsCorrectDateTime()
     {
         $delay = 10;
         $job = new Job('queue', 'body', 'id', $delay);
-        $this->assertEquals(time() + $delay, $job->getDatetimeDelay()->getTimestamp());
+        static::assertEquals(time() + $delay, $job->getDatetimeDelay()->getTimestamp());
     }
 
     public function testSetDelay()
@@ -47,7 +47,7 @@ class JobTest extends \PHPUnit_Framework_TestCase
         $delay = 10;
         $job = new Job('queue', 'body', 'id', 2000);
         $job->setDelay($delay);
-        $this->assertEquals($delay, $job->getDelay());
+        static::assertEquals($delay, $job->getDelay());
     }
 
     public function testSetTtr()
@@ -55,7 +55,7 @@ class JobTest extends \PHPUnit_Framework_TestCase
         $ttr = 60;
         $job = new Job('queue', 'body', 'id', 10, 10, 2000);
         $job->setTtr($ttr);
-        $this->assertEquals($ttr, $job->getTtr());
+        static::assertEquals($ttr, $job->getTtr());
     }
 
     public function testSetPriority()
@@ -63,6 +63,6 @@ class JobTest extends \PHPUnit_Framework_TestCase
         $priority = 100;
         $job = new Job('queue', 'body', 'id', 10, 2000);
         $job->setPriority($priority);
-        $this->assertEquals($priority, $job->getPriority());
+        static::assertEquals($priority, $job->getPriority());
     }
 }

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -4,8 +4,9 @@ namespace Phlib\JobQueue\Tests;
 
 use Phlib\JobQueue\Job;
 use Phlib\JobQueue\JobInterface;
+use PHPUnit\Framework\TestCase;
 
-class JobTest extends \PHPUnit_Framework_TestCase
+class JobTest extends TestCase
 {
     public function testInstanceOfJobInterface()
     {

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -3,12 +3,13 @@
 namespace Phlib\JobQueue\Tests;
 
 use Phlib\JobQueue\Job;
+use Phlib\JobQueue\JobInterface;
 
 class JobTest extends \PHPUnit_Framework_TestCase
 {
     public function testInstanceOfJobInterface()
     {
-        $this->assertInstanceOf('\Phlib\JobQueue\JobInterface', new Job('queue', 'body'));
+        $this->assertInstanceOf(JobInterface::class, new Job('queue', 'body'));
     }
 
     public function testEachProperty()

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -15,22 +15,22 @@ class JobTest extends \PHPUnit_Framework_TestCase
     public function testEachProperty()
     {
         $data = [
-            'queue'    => 'testQueue',
-            'body'     => 'Job Body',
-            'id'       => 'abc123',
-            'delay'    => 10,
+            'queue' => 'testQueue',
+            'body' => 'Job Body',
+            'id' => 'abc123',
+            'delay' => 10,
             'priority' => 5,
-            'ttr'      => 60,
+            'ttr' => 60,
         ];
         $job = new Job($data['queue'], $data['body'], $data['id'], $data['delay'], $data['priority'], $data['ttr']);
 
         $actual = [
-            'queue'    => $job->getQueue(),
-            'body'     => $job->getBody(),
-            'id'       => $job->getId(),
-            'delay'    => $job->getDelay(),
+            'queue' => $job->getQueue(),
+            'body' => $job->getBody(),
+            'id' => $job->getId(),
+            'delay' => $job->getDelay(),
             'priority' => $job->getPriority(),
-            'ttr'      => $job->getTtr(),
+            'ttr' => $job->getTtr(),
         ];
         static::assertSame($data, $actual);
     }

--- a/tests/Scheduler/DbSchedulerTest.php
+++ b/tests/Scheduler/DbSchedulerTest.php
@@ -6,8 +6,9 @@ use Phlib\Db\Adapter;
 use Phlib\JobQueue\JobInterface;
 use Phlib\JobQueue\Scheduler\DbScheduler;
 use Phlib\JobQueue\Scheduler\SchedulerInterface;
+use PHPUnit\Framework\TestCase;
 
-class DbSchedulerTest extends \PHPUnit_Framework_TestCase
+class DbSchedulerTest extends TestCase
 {
     /**
      * @var \Phlib\Db\Adapter|\PHPUnit_Framework_MockObject_MockObject
@@ -22,13 +23,10 @@ class DbSchedulerTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->adapter = $this->getMock(Adapter::class);
+        $this->adapter = $this->createMock(Adapter::class);
 
-        $this->quote = $this->getMockBuilder(Adapter\QuoteHandler::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->adapter->expects(static::any())
-            ->method('quote')
+        $this->quote = $this->createMock(Adapter\QuoteHandler::class);
+        $this->adapter->method('quote')
             ->willReturn($this->quote);
     }
 
@@ -60,18 +58,18 @@ class DbSchedulerTest extends \PHPUnit_Framework_TestCase
 
     public function testStoringJob()
     {
-        $pdoStatement = $this->getMock(\PDOStatement::class);
-        $pdoStatement->expects(static::any())
+        $pdoStatement = $this->createMock(\PDOStatement::class);
+        $pdoStatement->expects(static::once())
             ->method('rowCount')
-            ->will(static::returnValue(1));
-        $this->adapter->expects(static::any())
+            ->willReturn(1);
+        $this->adapter->expects(static::once())
             ->method('query')
-            ->will(static::returnValue($pdoStatement));
+            ->willReturn($pdoStatement);
 
-        $job = $this->getMock(JobInterface::class);
-        $job->expects(static::any())
+        $job = $this->createMock(JobInterface::class);
+        $job->expects(static::once())
             ->method('getDatetimeDelay')
-            ->will(static::returnValue(new \DateTime()));
+            ->willReturn(new \DateTime());
 
         $scheduler = new DbScheduler($this->adapter);
         static::assertTrue($scheduler->store($job));
@@ -79,13 +77,13 @@ class DbSchedulerTest extends \PHPUnit_Framework_TestCase
 
     public function testRetrieveWithNoResults()
     {
-        $stmt = $this->getMock(\PDOStatement::class);
-        $stmt->expects(static::any())
+        $stmt = $this->createMock(\PDOStatement::class);
+        $stmt->expects(static::once())
             ->method('rowCount')
-            ->will(static::returnValue(0));
-        $this->adapter->expects(static::any())
+            ->willReturn(0);
+        $this->adapter->expects(static::once())
             ->method('query')
-            ->will(static::returnValue($stmt));
+            ->willReturn($stmt);
         $scheduler = new DbScheduler($this->adapter);
         static::assertFalse($scheduler->retrieve());
     }
@@ -100,16 +98,16 @@ class DbSchedulerTest extends \PHPUnit_Framework_TestCase
             'priority' => 1024,
             'ttr' => 60,
         ];
-        $stmt = $this->getMock(\PDOStatement::class);
-        $stmt->expects(static::any())
+        $stmt = $this->createMock(\PDOStatement::class);
+        $stmt->expects(static::once())
             ->method('rowCount')
-            ->will(static::returnValue(1));
-        $stmt->expects(static::any())
+            ->willReturn(1);
+        $stmt->expects(static::atLeastOnce())
             ->method('fetch')
-            ->will(static::returnValue($rowData));
-        $this->adapter->expects(static::any())
+            ->willReturn($rowData);
+        $this->adapter->expects(static::atLeastOnce())
             ->method('query')
-            ->will(static::returnValue($stmt));
+            ->willReturn($stmt);
         $scheduler = new DbScheduler($this->adapter);
 
         $jobData = $scheduler->retrieve();
@@ -118,13 +116,13 @@ class DbSchedulerTest extends \PHPUnit_Framework_TestCase
 
     public function testRemove()
     {
-        $pdoStatement = $this->getMock(\PDOStatement::class);
-        $pdoStatement->expects(static::any())
+        $pdoStatement = $this->createMock(\PDOStatement::class);
+        $pdoStatement->expects(static::once())
             ->method('rowCount')
-            ->will(static::returnValue(1));
-        $this->adapter->expects(static::any())
+            ->willReturn(1);
+        $this->adapter->expects(static::once())
             ->method('query')
-            ->will(static::returnValue($pdoStatement));
+            ->willReturn($pdoStatement);
         $scheduler = new DbScheduler($this->adapter);
         static::assertTrue($scheduler->remove(234));
     }

--- a/tests/Scheduler/DbSchedulerTest.php
+++ b/tests/Scheduler/DbSchedulerTest.php
@@ -80,7 +80,7 @@ class DbSchedulerTest extends \PHPUnit_Framework_TestCase
 
     public function testRetrieveWithNoResults()
     {
-        $stmt = $this->getMock('\PDOStatement');
+        $stmt = $this->getMock(\PDOStatement::class);
         $stmt->expects($this->any())
             ->method('rowCount')
             ->will($this->returnValue(0));
@@ -101,7 +101,7 @@ class DbSchedulerTest extends \PHPUnit_Framework_TestCase
             'priority' => 1024,
             'ttr' => 60
         ];
-        $stmt = $this->getMock('\PDOStatement');
+        $stmt = $this->getMock(\PDOStatement::class);
         $stmt->expects($this->any())
             ->method('rowCount')
             ->will($this->returnValue(1));

--- a/tests/Scheduler/DbSchedulerTest.php
+++ b/tests/Scheduler/DbSchedulerTest.php
@@ -27,7 +27,7 @@ class DbSchedulerTest extends \PHPUnit_Framework_TestCase
         $this->quote = $this->getMockBuilder(Adapter\QuoteHandler::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->adapter->expects($this->any())
+        $this->adapter->expects(static::any())
             ->method('quote')
             ->willReturn($this->quote);
     }
@@ -41,54 +41,54 @@ class DbSchedulerTest extends \PHPUnit_Framework_TestCase
 
     public function testImplementsSchedulerInterface()
     {
-        $this->assertInstanceOf(SchedulerInterface::class, new DbScheduler($this->adapter));
+        static::assertInstanceOf(SchedulerInterface::class, new DbScheduler($this->adapter));
     }
 
     public function testShouldBeScheduled()
     {
         $maxDelay  = 300;
         $scheduler = new DbScheduler($this->adapter, $maxDelay);
-        $this->assertTrue($scheduler->shouldBeScheduled($maxDelay + 1));
+        static::assertTrue($scheduler->shouldBeScheduled($maxDelay + 1));
     }
 
     public function testShouldNotBeScheduled()
     {
         $maxDelay  = 300;
         $scheduler = new DbScheduler($this->adapter, $maxDelay);
-        $this->assertFalse($scheduler->shouldBeScheduled(60));
+        static::assertFalse($scheduler->shouldBeScheduled(60));
     }
 
     public function testStoringJob()
     {
         $pdoStatement = $this->getMock(\PDOStatement::class);
-        $pdoStatement->expects($this->any())
+        $pdoStatement->expects(static::any())
             ->method('rowCount')
-            ->will($this->returnValue(1));
-        $this->adapter->expects($this->any())
+            ->will(static::returnValue(1));
+        $this->adapter->expects(static::any())
             ->method('query')
-            ->will($this->returnValue($pdoStatement));
+            ->will(static::returnValue($pdoStatement));
 
         $job = $this->getMock(JobInterface::class);
-        $job->expects($this->any())
+        $job->expects(static::any())
             ->method('getDatetimeDelay')
-            ->will($this->returnValue(new \DateTime()));
+            ->will(static::returnValue(new \DateTime()));
 
         $scheduler = new DbScheduler($this->adapter);
-        $this->assertTrue($scheduler->store($job));
+        static::assertTrue($scheduler->store($job));
     }
 
 
     public function testRetrieveWithNoResults()
     {
         $stmt = $this->getMock(\PDOStatement::class);
-        $stmt->expects($this->any())
+        $stmt->expects(static::any())
             ->method('rowCount')
-            ->will($this->returnValue(0));
-        $this->adapter->expects($this->any())
+            ->will(static::returnValue(0));
+        $this->adapter->expects(static::any())
             ->method('query')
-            ->will($this->returnValue($stmt));
+            ->will(static::returnValue($stmt));
         $scheduler = new DbScheduler($this->adapter);
-        $this->assertFalse($scheduler->retrieve());
+        static::assertFalse($scheduler->retrieve());
     }
 
     public function testRetrieveCalculatesDelay()
@@ -102,31 +102,31 @@ class DbSchedulerTest extends \PHPUnit_Framework_TestCase
             'ttr' => 60
         ];
         $stmt = $this->getMock(\PDOStatement::class);
-        $stmt->expects($this->any())
+        $stmt->expects(static::any())
             ->method('rowCount')
-            ->will($this->returnValue(1));
-        $stmt->expects($this->any())
+            ->will(static::returnValue(1));
+        $stmt->expects(static::any())
             ->method('fetch')
-            ->will($this->returnValue($rowData));
-        $this->adapter->expects($this->any())
+            ->will(static::returnValue($rowData));
+        $this->adapter->expects(static::any())
             ->method('query')
-            ->will($this->returnValue($stmt));
+            ->will(static::returnValue($stmt));
         $scheduler = new DbScheduler($this->adapter);
 
         $jobData = $scheduler->retrieve();
-        $this->assertEquals(0, $jobData['delay']);
+        static::assertEquals(0, $jobData['delay']);
     }
 
     public function testRemove()
     {
         $pdoStatement = $this->getMock(\PDOStatement::class);
-        $pdoStatement->expects($this->any())
+        $pdoStatement->expects(static::any())
             ->method('rowCount')
-            ->will($this->returnValue(1));
-        $this->adapter->expects($this->any())
+            ->will(static::returnValue(1));
+        $this->adapter->expects(static::any())
             ->method('query')
-            ->will($this->returnValue($pdoStatement));
+            ->will(static::returnValue($pdoStatement));
         $scheduler = new DbScheduler($this->adapter);
-        $this->assertTrue($scheduler->remove(234));
+        static::assertTrue($scheduler->remove(234));
     }
 }

--- a/tests/Scheduler/DbSchedulerTest.php
+++ b/tests/Scheduler/DbSchedulerTest.php
@@ -6,17 +6,18 @@ use Phlib\Db\Adapter;
 use Phlib\JobQueue\JobInterface;
 use Phlib\JobQueue\Scheduler\DbScheduler;
 use Phlib\JobQueue\Scheduler\SchedulerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class DbSchedulerTest extends TestCase
 {
     /**
-     * @var \Phlib\Db\Adapter|\PHPUnit_Framework_MockObject_MockObject
+     * @var Adapter|MockObject
      */
     protected $adapter;
 
     /**
-     * @var \Phlib\Db\Adapter\QuoteHandler|\PHPUnit_Framework_MockObject_MockObject
+     * @var Adapter\QuoteHandler|MockObject
      */
     protected $quote;
 

--- a/tests/Scheduler/DbSchedulerTest.php
+++ b/tests/Scheduler/DbSchedulerTest.php
@@ -46,14 +46,14 @@ class DbSchedulerTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldBeScheduled()
     {
-        $maxDelay  = 300;
+        $maxDelay = 300;
         $scheduler = new DbScheduler($this->adapter, $maxDelay);
         static::assertTrue($scheduler->shouldBeScheduled($maxDelay + 1));
     }
 
     public function testShouldNotBeScheduled()
     {
-        $maxDelay  = 300;
+        $maxDelay = 300;
         $scheduler = new DbScheduler($this->adapter, $maxDelay);
         static::assertFalse($scheduler->shouldBeScheduled(60));
     }
@@ -77,7 +77,6 @@ class DbSchedulerTest extends \PHPUnit_Framework_TestCase
         static::assertTrue($scheduler->store($job));
     }
 
-
     public function testRetrieveWithNoResults()
     {
         $stmt = $this->getMock(\PDOStatement::class);
@@ -99,7 +98,7 @@ class DbSchedulerTest extends \PHPUnit_Framework_TestCase
             'data' => serialize('someData'),
             'scheduled_ts' => time(),
             'priority' => 1024,
-            'ttr' => 60
+            'ttr' => 60,
         ];
         $stmt = $this->getMock(\PDOStatement::class);
         $stmt->expects(static::any())

--- a/tests/Scheduler/DbSchedulerTest.php
+++ b/tests/Scheduler/DbSchedulerTest.php
@@ -20,7 +20,7 @@ class DbSchedulerTest extends TestCase
      */
     protected $quote;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->adapter = $this->createMock(Adapter::class);
@@ -30,33 +30,33 @@ class DbSchedulerTest extends TestCase
             ->willReturn($this->quote);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->quote = null;
         $this->adapter = null;
         parent::tearDown();
     }
 
-    public function testImplementsSchedulerInterface()
+    public function testImplementsSchedulerInterface(): void
     {
         static::assertInstanceOf(SchedulerInterface::class, new DbScheduler($this->adapter));
     }
 
-    public function testShouldBeScheduled()
+    public function testShouldBeScheduled(): void
     {
         $maxDelay = 300;
         $scheduler = new DbScheduler($this->adapter, $maxDelay);
         static::assertTrue($scheduler->shouldBeScheduled($maxDelay + 1));
     }
 
-    public function testShouldNotBeScheduled()
+    public function testShouldNotBeScheduled(): void
     {
         $maxDelay = 300;
         $scheduler = new DbScheduler($this->adapter, $maxDelay);
         static::assertFalse($scheduler->shouldBeScheduled(60));
     }
 
-    public function testStoringJob()
+    public function testStoringJob(): void
     {
         $pdoStatement = $this->createMock(\PDOStatement::class);
         $pdoStatement->expects(static::once())
@@ -75,7 +75,7 @@ class DbSchedulerTest extends TestCase
         static::assertTrue($scheduler->store($job));
     }
 
-    public function testRetrieveWithNoResults()
+    public function testRetrieveWithNoResults(): void
     {
         $stmt = $this->createMock(\PDOStatement::class);
         $stmt->expects(static::once())
@@ -88,7 +88,7 @@ class DbSchedulerTest extends TestCase
         static::assertFalse($scheduler->retrieve());
     }
 
-    public function testRetrieveCalculatesDelay()
+    public function testRetrieveCalculatesDelay(): void
     {
         $rowData = [
             'id' => 1,
@@ -114,7 +114,7 @@ class DbSchedulerTest extends TestCase
         static::assertEquals(0, $jobData['delay']);
     }
 
-    public function testRemove()
+    public function testRemove(): void
     {
         $pdoStatement = $this->createMock(\PDOStatement::class);
         $pdoStatement->expects(static::once())


### PR DESCRIPTION
- Removed support for PHP versions <= v7.1 (interim step).
- Add type declarations.
- Make return types consistent for `JobQueueInterface` methods.