### PR TITLE
PHP 8.4 deprecation warnings

### DIFF
--- a/src/Exception/JobRuntimeException.php
+++ b/src/Exception/JobRuntimeException.php
@@ -15,7 +15,7 @@ class JobRuntimeException extends RuntimeException
         protected JobInterface $job,
         string $message,
         int $code = 0,
-        \Throwable $previous = null,
+        ?\Throwable $previous = null,
     ) {
         parent::__construct($message, $code, $previous);
     }


### PR DESCRIPTION
This fixes a deprecation warning thrown by this library when running on PHP 8.4 with `E_DEPRECATED` reporting enabled
```
Phlib\JobQueue\Exception\JobRuntimeException::__construct(): Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead
```
Unit tests are still reporting a deprecation as there are some caused by the `phlib/beanstalk` library, these will be fixed by https://github.com/phlib/beanstalk/pull/40