### PR TITLE
Add batching support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Added `BatchableJobQueueInterface` which defines a JobQueue capable of putting jobs to a queue in batches.
+  - Extends `JobQueueInterface`.
+  - Adds `putBatch()` method, which accepts an array of `JobInterface` and returns `self`.
+- Added `BatchableSchedulerInterface` which defines a scheduler capable of retrieving and removing jobs in batches.
+  - Extends `SchedulerInterface`.
+  - Adds `retrieveBatch()` which will return a array of jobs or `false` if there are no jobs.
+  - Adds `removeBatch()` which accepts an array of job ids and returns a bool to indicate success.
+### Changed
+- `Phlib\JobQueue\AwsSqs\JobQueue` supports batching and implements `BatchableJobQueueInterface`.
+- `Phlib\JobQueue\Scheduler\DbScheduler` supports batching and implements `BatchableSchedulerInterface`.
+- `Phlib\JobQueue\Scheduler\DbScheduler` optionally accepts a `batchSize` argument to specify how many jobs should be fetched per query.
+  This defaults to `50` if not provided.
+- `MonitorCommand` will fetch jobs in batches if the scheduler implements `BatchableSchedulerInterface`.
+- `MonitorCommand` will put jobs in batches if the JobQueue implements `BatchableJobQueueInterface` and the scheduler support batching.
 
 ## [2.0.0] - 2022-09-14
 ### Added

--- a/src/AwsSqs/JobQueue.php
+++ b/src/AwsSqs/JobQueue.php
@@ -6,14 +6,14 @@ namespace Phlib\JobQueue\AwsSqs;
 
 use Aws\Sqs\Exception\SqsException;
 use Aws\Sqs\SqsClient;
+use Phlib\JobQueue\BatchableJobQueueInterface;
 use Phlib\JobQueue\Exception\InvalidArgumentException;
 use Phlib\JobQueue\Exception\RuntimeException;
 use Phlib\JobQueue\Job;
 use Phlib\JobQueue\JobInterface;
-use Phlib\JobQueue\JobQueueInterface;
 use Phlib\JobQueue\Scheduler\SchedulerInterface;
 
-class JobQueue implements JobQueueInterface
+class JobQueue implements BatchableJobQueueInterface
 {
     private SqsClient $client;
 
@@ -63,6 +63,39 @@ class JobQueue implements JobQueueInterface
                 'DelaySeconds' => $job->getDelay(),
                 'MessageBody' => JobFactory::serializeBody($job),
             ]);
+            return $this;
+        } catch (SqsException $exception) {
+            throw new RuntimeException($exception->getMessage(), $exception->getCode(), $exception);
+        }
+    }
+
+    public function putBatch(array $jobs): self
+    {
+        try {
+            $queues = [];
+
+            foreach ($jobs as $key => $job) {
+                if ($this->scheduler->shouldBeScheduled($job->getDelay())) {
+                    $this->scheduler->store($job);
+                    continue;
+                }
+
+                $queues[$job->getQueue()][] = [
+                    'Id' => (string) $key,
+                    'DelaySeconds' => $job->getDelay(),
+                    'MessageBody' => JobFactory::serializeBody($job),
+                ];
+            }
+
+            foreach ($queues as $queue => $jobs) {
+                foreach (array_chunk($jobs, 10) as $batch) {
+                    $this->client->sendMessageBatch([
+                        'QueueUrl' => $this->getQueueUrlWithPrefix($queue),
+                        'Entries' => $batch,
+                    ]);
+                }
+            }
+
             return $this;
         } catch (SqsException $exception) {
             throw new RuntimeException($exception->getMessage(), $exception->getCode(), $exception);

--- a/src/BatchableJobQueueInterface.php
+++ b/src/BatchableJobQueueInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlib\JobQueue;
+
+interface BatchableJobQueueInterface extends JobQueueInterface
+{
+    /**
+     * @param JobInterface[] $jobs
+     */
+    public function putBatch(array $jobs): self;
+}

--- a/src/Scheduler/BatchableSchedulerInterface.php
+++ b/src/Scheduler/BatchableSchedulerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlib\JobQueue\Scheduler;
+
+/**
+ * Interface BatchableSchedulerInterface
+ *
+ * @package Phlib\JobQueue
+ */
+interface BatchableSchedulerInterface extends SchedulerInterface
+{
+    /**
+     * @return array|false
+     */
+    public function retrieveBatch();
+
+    public function removeBatch(array $jobId): bool;
+}

--- a/tests/Scheduler/DbSchedulerTest.php
+++ b/tests/Scheduler/DbSchedulerTest.php
@@ -96,19 +96,21 @@ class DbSchedulerTest extends TestCase
     public function testRetrieveCalculatesDelay(): void
     {
         $rowData = [
-            'id' => 1,
-            'tube' => 'queue',
-            'data' => serialize('someData'),
-            'scheduled_ts' => date('Y-m-d H:i:s'),
-            'priority' => 1024,
-            'ttr' => 60,
+            [
+                'id' => 1,
+                'tube' => 'queue',
+                'data' => serialize('someData'),
+                'scheduled_ts' => date('Y-m-d H:i:s'),
+                'priority' => 1024,
+                'ttr' => 60,
+            ],
         ];
         $stmt = $this->createMock(\PDOStatement::class);
         $stmt->expects(static::once())
             ->method('rowCount')
             ->willReturn(1);
         $stmt->expects(static::atLeastOnce())
-            ->method('fetch')
+            ->method('fetchAll')
             ->willReturn($rowData);
         $this->adapter->expects(static::atLeastOnce())
             ->method('query')
@@ -130,5 +132,170 @@ class DbSchedulerTest extends TestCase
             ->willReturn($pdoStatement);
         $scheduler = new DbScheduler($this->adapter);
         static::assertTrue($scheduler->remove(234));
+    }
+
+    public function testRetrieveBatchWithNoResults(): void
+    {
+        $stmt = $this->createMock(\PDOStatement::class);
+        $stmt->expects(static::once())
+            ->method('rowCount')
+            ->willReturn(0);
+        $this->adapter->expects(static::once())
+            ->method('query')
+            ->willReturn($stmt);
+        $scheduler = new DbScheduler($this->adapter);
+        static::assertFalse($scheduler->retrieveBatch());
+    }
+
+    public function testRetrieveBatchWithResults(): void
+    {
+        $rowData = [
+            [
+                'id' => 1,
+                'tube' => 'queue1',
+                'data' => serialize('data1'),
+                'scheduled_ts' => date('Y-m-d H:i:s'),
+                'priority' => 1024,
+                'ttr' => 60,
+            ],
+            [
+                'id' => 2,
+                'tube' => 'queue2',
+                'data' => serialize('data2'),
+                'scheduled_ts' => date('Y-m-d H:i:s'),
+                'priority' => 512,
+                'ttr' => 30,
+            ],
+        ];
+
+        $updateStmt = $this->createMock(\PDOStatement::class);
+        $updateStmt->expects(static::once())
+            ->method('rowCount')
+            ->willReturn(2);
+
+        $selectStmt = $this->createMock(\PDOStatement::class);
+        $selectStmt->expects(static::once())
+            ->method('fetchAll')
+            ->willReturn($rowData);
+
+        $this->adapter->expects(static::exactly(2))
+            ->method('query')
+            ->willReturnOnConsecutiveCalls($updateStmt, $selectStmt);
+
+        $scheduler = new DbScheduler($this->adapter);
+        $jobs = $scheduler->retrieveBatch();
+
+        static::assertIsArray($jobs);
+        static::assertCount(2, $jobs);
+        static::assertSame(1, $jobs[0]['id']);
+        static::assertSame('queue1', $jobs[0]['queue']);
+        static::assertSame('data1', $jobs[0]['data']);
+        static::assertSame(0, $jobs[0]['delay']);
+        static::assertSame(1024, $jobs[0]['priority']);
+        static::assertSame(60, $jobs[0]['ttr']);
+    }
+
+    public function testRetrieveBatchCalculatesDelayCorrectly(): void
+    {
+        $futureTime = date('Y-m-d H:i:s', time() + 120);
+        $rowData = [
+            [
+                'id' => 1,
+                'tube' => 'queue',
+                'data' => serialize('data'),
+                'scheduled_ts' => $futureTime,
+                'priority' => 1024,
+                'ttr' => 60,
+            ],
+        ];
+
+        $updateStmt = $this->createMock(\PDOStatement::class);
+        $updateStmt->expects(static::once())
+            ->method('rowCount')
+            ->willReturn(1);
+
+        $selectStmt = $this->createMock(\PDOStatement::class);
+        $selectStmt->expects(static::once())
+            ->method('fetchAll')
+            ->willReturn($rowData);
+
+        $this->adapter->expects(static::exactly(2))
+            ->method('query')
+            ->willReturnOnConsecutiveCalls($updateStmt, $selectStmt);
+
+        $scheduler = new DbScheduler($this->adapter);
+        $jobs = $scheduler->retrieveBatch();
+
+        static::assertIsArray($jobs);
+        static::assertCount(1, $jobs);
+        static::assertSame(120, $jobs[0]['delay']);
+    }
+
+    public function testRemoveBatchWithSingleJob(): void
+    {
+        $this->quote->expects(static::once())
+            ->method('identifier')
+            ->with('scheduled_queue')
+            ->willReturn('`scheduled_queue`');
+
+        $pdoStatement = $this->createMock(\PDOStatement::class);
+        $pdoStatement->expects(static::once())
+            ->method('rowCount')
+            ->willReturn(1);
+
+        $this->adapter->expects(static::once())
+            ->method('query')
+            ->with(
+                'DELETE FROM `scheduled_queue` WHERE id IN ( ? )',
+                [123]
+            )
+            ->willReturn($pdoStatement);
+
+        $scheduler = new DbScheduler($this->adapter);
+        static::assertTrue($scheduler->removeBatch([123]));
+    }
+
+    public function testRemoveBatchWithMultipleJobs(): void
+    {
+        $this->quote->expects(static::once())
+            ->method('identifier')
+            ->with('scheduled_queue')
+            ->willReturn('`scheduled_queue`');
+
+        $pdoStatement = $this->createMock(\PDOStatement::class);
+        $pdoStatement->expects(static::once())
+            ->method('rowCount')
+            ->willReturn(3);
+
+        $this->adapter->expects(static::once())
+            ->method('query')
+            ->with(
+                'DELETE FROM `scheduled_queue` WHERE id IN ( ?,?,? )',
+                [123, 456, 789]
+            )
+            ->willReturn($pdoStatement);
+
+        $scheduler = new DbScheduler($this->adapter);
+        static::assertTrue($scheduler->removeBatch([123, 456, 789]));
+    }
+
+    public function testRemoveBatchWithNoRowsAffected(): void
+    {
+        $this->quote->expects(static::once())
+            ->method('identifier')
+            ->with('scheduled_queue')
+            ->willReturn('`scheduled_queue`');
+
+        $pdoStatement = $this->createMock(\PDOStatement::class);
+        $pdoStatement->expects(static::once())
+            ->method('rowCount')
+            ->willReturn(0);
+
+        $this->adapter->expects(static::once())
+            ->method('query')
+            ->willReturn($pdoStatement);
+
+        $scheduler = new DbScheduler($this->adapter);
+        static::assertFalse($scheduler->removeBatch([999]));
     }
 }


### PR DESCRIPTION
This adds batching support to the DbScheduler and SQS JobQueue, which will be used by the monitor command to improve thoughput.
There is now a batchable version of both `SchedulerInterface` and `JobQueueInterface`, which are used to determine if batching is supported.
DbScheduler has a configurable batch size to dermine how many records it will fetch. SQS will accept any number of jobs, but internally will split it into batches of 10 jobs per queue (which is the maximum AWS will accept at once).