### PR TITLE
Fix compatibility with ElasticMQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fix `Phlib\JobQueue\AwsSqs\JobQueue` throwing an exception when `JobQueue->retrieve()` is called on an empty queue and using an ElasticMQ server.
 
 ## [3.2.0] - 2025-11-11
 ### Changed

--- a/src/AwsSqs/JobQueue.php
+++ b/src/AwsSqs/JobQueue.php
@@ -104,7 +104,7 @@ class JobQueue implements BatchableJobQueueInterface
                 'MaxNumberOfMessages' => 1,
             ]);
 
-            if (!isset($result['Messages'])) {
+            if (empty($result['Messages'])) {
                 return null;
             }
 


### PR DESCRIPTION
This PR changes the `Phlib\JobQueue\AwsSqs\JobQueue` so it is compatible with [ElasticMQ](https://github.com/softwaremill/elasticmq), which is a message queue server which is compatible with AWS SQS.

The only difference with ElasticMQ that seems to affect this library is that receiving from an empty queue will result in an empty `$result['Messages']` array whereas AWS will not return the `Messages` property in the response at all. Funnily, this looks to be a better implementation of the [AWS spec](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html#API_ReceiveMessage_ResponseSyntax) than AWS managed, as the spec specifies that the `Messages` array will always be in the response and does not mark it as optional.